### PR TITLE
Add the option to autocorrect files on save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log*
 out
 src/*.js
 *.vsix
+# test/tmp/**/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ npm-debug.log*
 out
 src/*.js
 *.vsix
-# test/tmp/**/*
+test/tmp/**/*

--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
           "default": false,
           "description": "start a Rubocop server for faster execution (since Rubocop 1.31)"
         },
+        "ruby.rubocop.autocorrectOnSave": {
+          "type": "boolean",
+          "default": false,
+          "description": "autocorrect files on save (requires `ruby.rubocop.onSave` to be set to `true`)"
+        },
         "ruby.rubocop.suppressRubocopWarnings": {
           "type": "boolean",
           "default": false,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -7,6 +7,7 @@ import { Rubocop } from './rubocop';
 export interface RubocopConfig {
   command: string;
   onSave: boolean;
+  autocorrectOnSave: boolean;
   configFilePath: string;
   useBundler: boolean;
   useServer: boolean;
@@ -75,6 +76,7 @@ export const getConfig: () => RubocopConfig = () => {
     command,
     configFilePath: conf.get('configFilePath', ''),
     onSave: conf.get('onSave', true),
+    autocorrectOnSave: conf.get('autocorrectOnSave', false),
     useBundler,
     useServer,
     suppressRubocopWarnings,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -54,7 +54,6 @@ export const getConfig: () => RubocopConfig = () => {
   const configPath = conf.get('executePath', '');
   const suppressRubocopWarnings = conf.get('suppressRubocopWarnings', false);
   let command: string;
-  console.debug('Using Rubocop server: ' + useServer);
 
   // if executePath is present in workspace config, use it.
   if (configPath.length !== 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,10 @@ export function activate(context: vscode.ExtensionContext): void {
     rubocop.execute(e);
   });
 
+  ws.onWillSaveTextDocument(() => {
+    if (rubocop.isOnSave && rubocop.autocorrectOnSave) vscode.commands.executeCommand('ruby.rubocop.autocorrect');
+  });
+
   ws.onDidSaveTextDocument((e: vscode.TextDocument) => {
     if (rubocop.isOnSave) {
       rubocop.execute(e);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Rubocop, RubocopAutocorrectProvider } from './rubocop';
+import { Rubocop } from './rubocop';
 import { onDidChangeConfiguration } from './configuration';
 
 // entry point of extension
@@ -30,7 +30,7 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
   ws.onWillSaveTextDocument(() => {
-    rubocop.executeAutocorrect();
+    rubocop.executeAutocorrectOnSave();
   });
 
   ws.onDidSaveTextDocument((e: vscode.TextDocument) => {
@@ -42,36 +42,20 @@ export function activate(context: vscode.ExtensionContext): void {
   ws.onDidCloseTextDocument((e: vscode.TextDocument) => {
     rubocop.clear(e);
   });
-  const formattingProvider = new RubocopAutocorrectProvider();
+
   vscode.languages.registerDocumentFormattingEditProvider(
     'ruby',
-    formattingProvider
+    rubocop.formattingProvider
   );
   vscode.languages.registerDocumentFormattingEditProvider(
     'gemfile',
-    formattingProvider
+    rubocop.formattingProvider
   );
 
   const autocorrectDisposable = vscode.commands.registerCommand(
     'ruby.rubocop.autocorrect',
     () => {
-      vscode.window.activeTextEditor?.edit((editBuilder) => {
-        const document = vscode.window.activeTextEditor.document;
-        const edits =
-          formattingProvider.provideDocumentFormattingEdits(document);
-        // We only expect one edit from our formatting provider.
-        if (edits.length === 1) {
-          const edit = edits[0];
-          editBuilder.replace(edit.range, edit.newText);
-        }
-        if (edits.length > 1) {
-          throw new Error(
-            'Unexpected error: Rubocop document formatter returned multiple edits.'
-          );
-        }
-      });
-
-      return true;
+      return rubocop.executeAutocorrect();
     }
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
   ws.onWillSaveTextDocument(() => {
-    if (rubocop.isOnSave && rubocop.autocorrectOnSave) vscode.commands.executeCommand('ruby.rubocop.autocorrect');
+    rubocop.executeAutocorrect();
   });
 
   ws.onDidSaveTextDocument((e: vscode.TextDocument) => {
@@ -52,20 +52,28 @@ export function activate(context: vscode.ExtensionContext): void {
     formattingProvider
   );
 
-const autocorrectDisposable = vscode.commands.registerCommand('ruby.rubocop.autocorrect', () => {
-  vscode.window.activeTextEditor.edit((editBuilder) => {
-    const document = vscode.window.activeTextEditor.document;
-    const edits = formattingProvider.provideDocumentFormattingEdits(document);
-    // We only expect one edit from our formatting provider.
-    if (edits.length === 1) {
-      const edit = edits[0];
-      editBuilder.replace(edit.range, edit.newText);
-    }
-    if (edits.length > 1) {
-      throw new Error("Unexpected error: Rubocop document formatter returned multiple edits.");
-    }
-  });
-});
+  const autocorrectDisposable = vscode.commands.registerCommand(
+    'ruby.rubocop.autocorrect',
+    () => {
+      vscode.window.activeTextEditor?.edit((editBuilder) => {
+        const document = vscode.window.activeTextEditor.document;
+        const edits =
+          formattingProvider.provideDocumentFormattingEdits(document);
+        // We only expect one edit from our formatting provider.
+        if (edits.length === 1) {
+          const edit = edits[0];
+          editBuilder.replace(edit.range, edit.newText);
+        }
+        if (edits.length > 1) {
+          throw new Error(
+            'Unexpected error: Rubocop document formatter returned multiple edits.'
+          );
+        }
+      });
 
-context.subscriptions.push(autocorrectDisposable);
+      return true;
+    }
+  );
+
+  context.subscriptions.push(autocorrectDisposable);
 }

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -15,15 +15,12 @@ export class RubocopAutocorrectProvider
   ): vscode.TextEdit[] {
     const config = getConfig();
     try {
-      const args = [
-        ...getCommandArguments(document.fileName),
-        '--autocorrect',
-      ];
+      const args = [...getCommandArguments(document.fileName), '--autocorrect'];
 
       if (config.useServer) {
         args.push('--server');
       }
-      
+
       const options = {
         cwd: getCurrentPath(document.uri),
         input: document.getText(),
@@ -132,6 +129,12 @@ export class Rubocop {
     this.diag = diagnostics;
     this.additionalArguments = additionalArguments;
     this.config = getConfig();
+  }
+
+  public async executeAutocorrect(): Promise<boolean> {
+    if (!this.isOnSave || !this.autocorrectOnSave) return false;
+
+    return await vscode.commands.executeCommand('ruby.rubocop.autocorrect');
   }
 
   public execute(document: vscode.TextDocument, onComplete?: () => void): void {

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -209,6 +209,10 @@ export class Rubocop {
     return this.config.onSave;
   }
 
+  public get autocorrectOnSave(): boolean {
+    return this.config.autocorrectOnSave;
+  }
+
   public clear(document: vscode.TextDocument): void {
     const uri = document.uri;
     if (isFileUri(uri)) {

--- a/src/rubocopOutput.ts
+++ b/src/rubocopOutput.ts
@@ -16,6 +16,7 @@ export interface RubocopOffense {
   message: string;
   cop_name: string;
   corrected: boolean;
+  correctable: boolean;
   location: RubocopLocation;
 }
 

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -19,6 +19,7 @@ vsStub.workspace.getConfiguration = (
     configfilePath: '',
     executePath: '',
     onSave: true,
+    autocorrectOnSave: false,
     useBundler: false,
     suppressRubocopWarnings: false,
   };
@@ -56,6 +57,16 @@ describe('RubocopConfig', () => {
       it('is unset if a bundled rubocop is not found', () => {
         childProcessStub.execSync = cannotFindBundledCop;
         expect(getConfig()).to.have.property('useBundler', false);
+      });
+    });
+
+    describe('.autocorrectOnSave', () => {
+      it('is set', () => {
+        expect(getConfig()).to.have.property('autocorrectOnSave');
+      });
+
+      it('is set to false by default', () => {
+        expect(getConfig()).to.have.property('autocorrectOnSave', false);
       });
     });
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,0 +1,9 @@
+export const fileWithWarnings = `
+  def someMethod(    arg )
+    if arg
+      return arg
+    end
+
+    return :default
+    end                    
+`;

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import { writeFileSync } from 'fs';
+import * as path from 'path';
+
+export const projectRootDir = path.resolve(path.join(__dirname, '..', '..'));
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function closeAllEditors() {
+  return await vscode.commands.executeCommand(
+    'workbench.action.closeAllEditors'
+  );
+}
+
+export async function openFile(fileName: string): Promise<vscode.TextDocument> {
+  const document = vscode.workspace.openTextDocument(fileName);
+  vscode.window.showTextDocument(await document);
+  return document;
+}
+
+export function createTempFile(fileName: string, content: string): string {
+  const filePath = path.join(projectRootDir, 'test', 'tmp', fileName);
+  writeFileSync(filePath, content);
+
+  return filePath;
+}

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -16,10 +16,9 @@ export async function closeAllEditors() {
   );
 }
 
-export async function openFile(fileName: string): Promise<vscode.TextDocument> {
-  const document = vscode.workspace.openTextDocument(fileName);
-  vscode.window.showTextDocument(await document);
-  return document;
+export async function openFile(fileName: string): Promise<vscode.TextEditor> {
+  const document = await vscode.workspace.openTextDocument(fileName);
+  return await vscode.window.showTextDocument(document);
 }
 
 export function createTempFile(fileName: string, content: string): string {

--- a/test/rubocop.test.ts
+++ b/test/rubocop.test.ts
@@ -24,8 +24,8 @@ describe('Rubocop', () => {
   });
 
   describe('autocorrectOnSave', () => {
-    it('does not work when config option is disabled', async function() {
-      this.timeout(5000)
+    it('does not work when config option is disabled', async function () {
+      this.timeout(5000);
       await helper.closeAllEditors();
 
       const filePath = helper.createTempFile(
@@ -33,7 +33,7 @@ describe('Rubocop', () => {
         fileWithWarnings
       );
       await helper.openFile(filePath);
-      expect(await instance.executeAutocorrect()).to.be.equal(false);
+      expect(instance.executeAutocorrectOnSave()).to.be.equal(false);
 
       await helper.sleep(1000);
       const fileAfterAutocorrect =
@@ -59,7 +59,7 @@ describe('Rubocop', () => {
         fileWithWarnings
       );
       await helper.openFile(filePath);
-      expect(await instance.executeAutocorrect()).to.be.equal(true);
+      expect(instance.executeAutocorrectOnSave()).to.be.equal(true);
 
       const fileAfterAutocorrect =
         vscode.window.activeTextEditor?.document?.getText();

--- a/test/rubocop.test.ts
+++ b/test/rubocop.test.ts
@@ -32,12 +32,11 @@ describe('Rubocop', () => {
         'file_with_warnings.rb',
         fileWithWarnings
       );
-      await helper.openFile(filePath);
+      const editor = await helper.openFile(filePath);
       expect(instance.executeAutocorrectOnSave()).to.be.equal(false);
 
-      await helper.sleep(1000);
-      const fileAfterAutocorrect =
-        vscode.window.activeTextEditor?.document?.getText();
+      await helper.sleep(500);
+      const fileAfterAutocorrect = editor.document?.getText();
 
       // Assert that there have been no changes
       expect(fileAfterAutocorrect).to.be.equal(fileWithWarnings);
@@ -45,7 +44,8 @@ describe('Rubocop', () => {
       fs.unlinkSync(filePath);
     });
 
-    it('works when config option is enabled', async () => {
+    it('works when config option is enabled', async function () {
+      this.timeout(5000);
       await helper.closeAllEditors();
 
       instance.config = {
@@ -58,11 +58,11 @@ describe('Rubocop', () => {
         'file_with_warnings.rb',
         fileWithWarnings
       );
-      await helper.openFile(filePath);
+      const editor = await helper.openFile(filePath);
       expect(instance.executeAutocorrectOnSave()).to.be.equal(true);
 
-      const fileAfterAutocorrect =
-        vscode.window.activeTextEditor?.document?.getText();
+      await helper.sleep(500)
+      const fileAfterAutocorrect = editor.document?.getText();
 
       // Assert that there have been changes
       expect(fileAfterAutocorrect).not.to.be.equal(fileWithWarnings);

--- a/test/rubocop.test.ts
+++ b/test/rubocop.test.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+
+import * as helper from './helper';
+import { fileWithWarnings } from './fixtures';
 import { Rubocop } from '../src/rubocop';
 
 describe('Rubocop', () => {
@@ -16,6 +20,54 @@ describe('Rubocop', () => {
       it('is set to the provided DiagnosticCollection', () => {
         expect(instance).to.have.property('diag', diagnostics);
       });
+    });
+  });
+
+  describe('autocorrectOnSave', () => {
+    it('does not work when config option is disabled', async function() {
+      this.timeout(5000)
+      await helper.closeAllEditors();
+
+      const filePath = helper.createTempFile(
+        'file_with_warnings.rb',
+        fileWithWarnings
+      );
+      await helper.openFile(filePath);
+      expect(await instance.executeAutocorrect()).to.be.equal(false);
+
+      await helper.sleep(1000);
+      const fileAfterAutocorrect =
+        vscode.window.activeTextEditor?.document?.getText();
+
+      // Assert that there have been no changes
+      expect(fileAfterAutocorrect).to.be.equal(fileWithWarnings);
+
+      fs.unlinkSync(filePath);
+    });
+
+    it('works when config option is enabled', async () => {
+      await helper.closeAllEditors();
+
+      instance.config = {
+        ...instance.config,
+        onSave: true,
+        autocorrectOnSave: true,
+      };
+
+      const filePath = helper.createTempFile(
+        'file_with_warnings.rb',
+        fileWithWarnings
+      );
+      await helper.openFile(filePath);
+      expect(await instance.executeAutocorrect()).to.be.equal(true);
+
+      const fileAfterAutocorrect =
+        vscode.window.activeTextEditor?.document?.getText();
+
+      // Assert that there have been changes
+      expect(fileAfterAutocorrect).not.to.be.equal(fileWithWarnings);
+
+      fs.unlinkSync(filePath);
     });
   });
 });


### PR DESCRIPTION
Hi, I implemented a new configuration option `autocorrectOnSave`.
This option is disabled by default. 

Files are automatically autocorrected on save when this option is enabled.

I think it would be a nice addition to this extension. While the existing autocorrection on-demand is certainly a better solution for most projects, there are situations in which autocorrection on file save can be useful.

I've worked on projects with less experienced developers and I found this feature to be very useful in ESLint. It strictly enforces a standard for how code should be written, which can help with onboarding new teammates.