### PR TITLE
Don't autocorrect files on save when the currently open file is not Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # 0.9.2
-- Addded option to autocorrect a file on save (thanks [@Verseth](https://github.com/Verseth)
+
+- Addded option to autocorrect a file on save (thanks [@Verseth](https://github.com/Verseth))
+
 # 0.9.1
+
 - Changed command description case style to match other extensions
-- Fixed bug where running 'Ruby: Autocorrect by Rubocop' would run the default formatter instead of Rubocop (thanks [@jvilk-stripe](https://github.com/jvilk-stripe), see https://github.com/LoranKloeze/vscode-ruby-rubocop-revived/issues/1#issue-1329266889) 
+- Fixed bug where running 'Ruby: Autocorrect by Rubocop' would run the default formatter instead of Rubocop (thanks [@jvilk-stripe](https://github.com/jvilk-stripe), see https://github.com/LoranKloeze/vscode-ruby-rubocop-revived/issues/1#issue-1329266889)
+
 # 0.9.0
 - Replace deprecated Rubocop argument --auto-correct with --autocorrect
 - Add a configuration option to run Rubocop in server mode (to speed up things). This option is available from >= Rubocop 1.31.

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -135,7 +135,7 @@ export class Rubocop {
 
   public executeAutocorrectOnSave(): boolean {
     const document = vscode.window.activeTextEditor?.document;
-    if (document === null || document === undefined) return;
+    if (document === null || document === undefined) return false;
     if ((document.languageId !== 'gemfile' && document.languageId !== 'ruby') || document.isUntitled || !isFileUri(document.uri)) return false;
     if (!this.isOnSave || !this.autocorrectOnSave) return false;
 

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -134,6 +134,9 @@ export class Rubocop {
   }
 
   public executeAutocorrectOnSave(): boolean {
+    const document = vscode.window.activeTextEditor?.document;
+    if (document === null || document === undefined) return;
+    if ((document.languageId !== 'gemfile' && document.languageId !== 'ruby') || document.isUntitled || !isFileUri(document.uri)) return false;
     if (!this.isOnSave || !this.autocorrectOnSave) return false;
 
     return this.executeAutocorrect();

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,4 +1,4 @@
-export const fileWithWarnings = `
+export const rubyFileWithWarnings = `
   def someMethod(    arg )
     if arg
       return arg
@@ -6,4 +6,12 @@ export const fileWithWarnings = `
 
     return :default
     end                    
+`;
+
+export const jsFile = `
+  function printHello() {
+    console.log("Hi i'm JavaScript!")
+  }
+
+  let something = 3;
 `;

--- a/test/rubocop.test.ts
+++ b/test/rubocop.test.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 
 import * as helper from './helper';
-import { fileWithWarnings } from './fixtures';
+import * as fixtures from './fixtures';
 import { Rubocop } from '../src/rubocop';
 
 describe('Rubocop', () => {
@@ -24,13 +24,13 @@ describe('Rubocop', () => {
   });
 
   describe('autocorrectOnSave', () => {
-    it('does not work when config option is disabled', async function () {
+    it('does not work on Ruby files when config option is disabled', async function () {
       this.timeout(5000);
       await helper.closeAllEditors();
 
       const filePath = helper.createTempFile(
         'file_with_warnings.rb',
-        fileWithWarnings
+        fixtures.rubyFileWithWarnings
       );
       const editor = await helper.openFile(filePath);
       expect(instance.executeAutocorrectOnSave()).to.be.equal(false);
@@ -39,12 +39,38 @@ describe('Rubocop', () => {
       const fileAfterAutocorrect = editor.document?.getText();
 
       // Assert that there have been no changes
-      expect(fileAfterAutocorrect).to.be.equal(fileWithWarnings);
+      expect(fileAfterAutocorrect).to.be.equal(fixtures.rubyFileWithWarnings);
 
       fs.unlinkSync(filePath);
     });
 
-    it('works when config option is enabled', async function () {
+    it('does not work on non-Ruby files when config option is enabled', async function () {
+      this.timeout(5000);
+      await helper.closeAllEditors();
+
+      instance.config = {
+        ...instance.config,
+        onSave: true,
+        autocorrectOnSave: true,
+      };
+
+      const filePath = helper.createTempFile(
+        'test_file.js',
+        fixtures.jsFile
+      );
+      const editor = await helper.openFile(filePath);
+      expect(instance.executeAutocorrectOnSave()).to.be.equal(false);
+
+      await helper.sleep(500);
+      const fileAfterAutocorrect = editor.document?.getText();
+
+      // Assert that there have been no changes
+      expect(fileAfterAutocorrect).to.be.equal(fixtures.jsFile);
+
+      fs.unlinkSync(filePath);
+    });
+
+    it('works on Ruby files when config option is enabled', async function () {
       this.timeout(5000);
       await helper.closeAllEditors();
 
@@ -56,7 +82,7 @@ describe('Rubocop', () => {
 
       const filePath = helper.createTempFile(
         'file_with_warnings.rb',
-        fileWithWarnings
+        fixtures.rubyFileWithWarnings
       );
       const editor = await helper.openFile(filePath);
       expect(instance.executeAutocorrectOnSave()).to.be.equal(true);
@@ -65,7 +91,7 @@ describe('Rubocop', () => {
       const fileAfterAutocorrect = editor.document?.getText();
 
       // Assert that there have been changes
-      expect(fileAfterAutocorrect).not.to.be.equal(fileWithWarnings);
+      expect(fileAfterAutocorrect).not.to.be.equal(fixtures.rubyFileWithWarnings);
 
       fs.unlinkSync(filePath);
     });


### PR DESCRIPTION
Hi, I've noticed a small bug while using the `autocorrectOnSave` feature.

Rubocop would attempt to correct non-Ruby files.
I've fixed this issue and covered this edge case with a new test.