### PR TITLE
Implement quick fixes for Rubocop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.9.3 (not released yet)
 
+- Introduce quick fix functionality that gives you the possibility to fix or ignore one or more errors (thanks [@Verseth](https://github.com/Verseth)) 
 - Bugfix where even non-Ruby files were autocorrected (thanks [@Verseth](https://github.com/Verseth)) 
 
 # 0.9.2

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ When autoCorrect is enabled, the history of changing file is broken.
 - lint by executing the command "Ruby: lint by rubocop" (cmd+shift+p and type command)
 - auto correct when saving a file
 - auto correct command "Ruby: autocorrect by rubocop"
+- quick fixes so you can fix or ignore an error [PR with explanation](https://github.com/LoranKloeze/vscode-ruby-rubocop-revived/pull/7)
 
 ### Exclude file
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,12 +52,39 @@ export function activate(context: vscode.ExtensionContext): void {
     rubocop.formattingProvider
   );
 
+  vscode.languages.registerCodeActionsProvider(
+    'ruby',
+    rubocop.quickFixProvider
+  );
+  vscode.languages.registerCodeActionsProvider(
+    'gemfile',
+    rubocop.quickFixProvider
+  );
+
   const autocorrectDisposable = vscode.commands.registerCommand(
     'ruby.rubocop.autocorrect',
-    () => {
-      return rubocop.executeAutocorrect();
+    (...args) => {
+      rubocop.executeAutocorrect(
+        args,
+        () => vscode.commands.executeCommand('ruby.rubocop')
+      );
     }
   );
 
   context.subscriptions.push(autocorrectDisposable);
+
+  const disableCopDisposable = vscode.commands.registerCommand(
+    'ruby.rubocop.disableCop',
+    (workspaceFolder?: vscode.WorkspaceFolder, copName?: string) => {
+      if(workspaceFolder === null || copName === null) return;
+
+      rubocop.disableCop(
+        workspaceFolder,
+        copName,
+        () => vscode.commands.executeCommand('ruby.rubocop')
+      );
+    }
+  );
+
+  context.subscriptions.push(disableCopDisposable);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,9 +10,9 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(diag);
 
   const rubocop = new Rubocop(diag);
-  const disposable = vscode.commands.registerCommand('ruby.rubocop', () => {
+  const disposable = vscode.commands.registerCommand('ruby.rubocop', (onComplete?: () => void) => {
     const document = vscode.window.activeTextEditor.document;
-    rubocop.execute(document);
+    rubocop.execute(document, onComplete);
   });
 
   context.subscriptions.push(disposable);

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { getConfig } from './configuration';
+
+export function isFileUri(uri: vscode.Uri): boolean {
+  return uri.scheme === 'file';
+}
+
+export function getCurrentPath(fileUri: vscode.Uri): string {
+  const wsfolder = vscode.workspace.getWorkspaceFolder(fileUri);
+  return (wsfolder && wsfolder.uri.fsPath) || path.dirname(fileUri.fsPath);
+}
+
+// extract argument to an array
+export function getCommandArguments(fileName: string): string[] {
+  let commandArguments = ['--stdin', fileName, '--force-exclusion'];
+  const extensionConfig = getConfig();
+  if (extensionConfig.configFilePath !== '') {
+    const found = [extensionConfig.configFilePath]
+      .concat(
+        (vscode.workspace.workspaceFolders || []).map((ws) =>
+          path.join(ws.uri.path, extensionConfig.configFilePath)
+        )
+      )
+      .filter((p: string) => fs.existsSync(p));
+
+    if (found.length == 0) {
+      vscode.window.showWarningMessage(
+        `${extensionConfig.configFilePath} file does not exist. Ignoring...`
+      );
+    } else {
+      if (found.length > 1) {
+        vscode.window.showWarningMessage(
+          `Found multiple files (${found}) will use ${found[0]}`
+        );
+      }
+      const config = ['--config', found[0]];
+      commandArguments = commandArguments.concat(config);
+    }
+  }
+
+  return commandArguments;
+}

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -1,120 +1,12 @@
-import { RubocopOutput, RubocopFile, RubocopOffense } from './rubocopOutput';
-import { TaskQueue, Task } from './taskQueue';
 import * as cp from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import { getConfig, RubocopConfig } from './configuration';
 import { ExecFileException } from 'child_process';
 
-export class RubocopAutocorrectProvider
-  implements vscode.DocumentFormattingEditProvider
-{
-  public provideDocumentFormattingEdits(
-    document: vscode.TextDocument
-  ): vscode.TextEdit[] {
-    const config = getConfig();
-    try {
-      const args = [...getCommandArguments(document.fileName), '--autocorrect'];
-
-      if (config.useServer) {
-        args.push('--server');
-      }
-
-      const options = {
-        cwd: getCurrentPath(document.uri),
-        input: document.getText(),
-      };
-      let stdout;
-      if (config.useBundler) {
-        stdout = cp.execSync(`${config.command} ${args.join(' ')}`, options);
-      } else {
-        stdout = cp.execFileSync(config.command, args, options);
-      }
-
-      return this.onSuccess(document, stdout);
-    } catch (e) {
-      // if there are still some offences not fixed RuboCop will return status 1
-      if (e.status !== 1) {
-        vscode.window.showWarningMessage(
-          'An error occurred during auto-correction'
-        );
-        console.log(e);
-        return [];
-      } else {
-        return this.onSuccess(document, e.stdout);
-      }
-    }
-  }
-
-  // Output of auto-correction looks like this:
-  //
-  // {"metadata": ... {"offense_count":5,"target_file_count":1,"inspected_file_count":1}}====================
-  // def a
-  //   3
-  // end
-  //
-  // So we need to parse out the actual auto-corrected ruby
-  private onSuccess(document: vscode.TextDocument, stdout: Buffer) {
-    const stringOut = stdout.toString();
-    const autoCorrection = stringOut.match(
-      /^.*\n====================(?:\n|\r\n)([.\s\S]*)/m
-    );
-    if (!autoCorrection) {
-      throw new Error(`Error parsing auto-correction from CLI: ${stringOut}`);
-    }
-    return [
-      new vscode.TextEdit(this.getFullRange(document), autoCorrection.pop()),
-    ];
-  }
-
-  private getFullRange(document: vscode.TextDocument): vscode.Range {
-    return new vscode.Range(
-      new vscode.Position(0, 0),
-      document.lineAt(document.lineCount - 1).range.end
-    );
-  }
-}
-
-function isFileUri(uri: vscode.Uri): boolean {
-  return uri.scheme === 'file';
-}
-
-function getCurrentPath(fileUri: vscode.Uri): string {
-  const wsfolder = vscode.workspace.getWorkspaceFolder(fileUri);
-  return (wsfolder && wsfolder.uri.fsPath) || path.dirname(fileUri.fsPath);
-}
-
-// extract argument to an array
-function getCommandArguments(fileName: string): string[] {
-  let commandArguments = ['--stdin', fileName, '--force-exclusion'];
-  const extensionConfig = getConfig();
-  if (extensionConfig.configFilePath !== '') {
-    const found = [extensionConfig.configFilePath]
-      .concat(
-        (vscode.workspace.workspaceFolders || []).map((ws) =>
-          path.join(ws.uri.path, extensionConfig.configFilePath)
-        )
-      )
-      .filter((p: string) => fs.existsSync(p));
-
-    if (found.length == 0) {
-      vscode.window.showWarningMessage(
-        `${extensionConfig.configFilePath} file does not exist. Ignoring...`
-      );
-    } else {
-      if (found.length > 1) {
-        vscode.window.showWarningMessage(
-          `Found multiple files (${found}) will use ${found[0]}`
-        );
-      }
-      const config = ['--config', found[0]];
-      commandArguments = commandArguments.concat(config);
-    }
-  }
-
-  return commandArguments;
-}
+import { RubocopOutput, RubocopFile, RubocopOffense } from './rubocopOutput';
+import { TaskQueue, Task } from './taskQueue';
+import { getConfig, RubocopConfig } from './configuration';
+import RubocopAutocorrectProvider from './rubocopAutocorrectProvider';
+import { getCommandArguments, isFileUri, getCurrentPath } from './helper';
 
 export class Rubocop {
   public config: RubocopConfig;

--- a/src/rubocopAutocorrectProvider.ts
+++ b/src/rubocopAutocorrectProvider.ts
@@ -7,12 +7,15 @@ import { getCommandArguments, getCurrentPath } from './helper';
 export default class RubocopAutocorrectProvider
   implements vscode.DocumentFormattingEditProvider
 {
-  public provideDocumentFormattingEdits(
-    document: vscode.TextDocument
-  ): vscode.TextEdit[] {
+  public provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
+    return this.getAutocorrectEdits(document);
+  }
+
+  public getAutocorrectEdits(document: vscode.TextDocument, additionalArguments: string[] = []): vscode.TextEdit[] {
     const config = getConfig();
     try {
-      const args = [...getCommandArguments(document.fileName), '--autocorrect'];
+      const args = [...getCommandArguments(document.fileName), ...additionalArguments];
+      if(additionalArguments.length === 0) args.push('--autocorrect');
 
       if (config.useServer) {
         args.push('--server');

--- a/src/rubocopAutocorrectProvider.ts
+++ b/src/rubocopAutocorrectProvider.ts
@@ -1,0 +1,74 @@
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+
+import { getConfig } from './configuration';
+import { getCommandArguments, getCurrentPath } from './helper';
+
+export default class RubocopAutocorrectProvider
+  implements vscode.DocumentFormattingEditProvider
+{
+  public provideDocumentFormattingEdits(
+    document: vscode.TextDocument
+  ): vscode.TextEdit[] {
+    const config = getConfig();
+    try {
+      const args = [...getCommandArguments(document.fileName), '--autocorrect'];
+
+      if (config.useServer) {
+        args.push('--server');
+      }
+
+      const options = {
+        cwd: getCurrentPath(document.uri),
+        input: document.getText(),
+      };
+      let stdout;
+      if (config.useBundler) {
+        stdout = cp.execSync(`${config.command} ${args.join(' ')}`, options);
+      } else {
+        stdout = cp.execFileSync(config.command, args, options);
+      }
+
+      return this.onSuccess(document, stdout);
+    } catch (e) {
+      // if there are still some offences not fixed RuboCop will return status 1
+      if (e.status !== 1) {
+        vscode.window.showWarningMessage(
+          'An error occurred during auto-correction'
+        );
+        console.log(e);
+        return [];
+      } else {
+        return this.onSuccess(document, e.stdout);
+      }
+    }
+  }
+
+  // Output of auto-correction looks like this:
+  //
+  // {"metadata": ... {"offense_count":5,"target_file_count":1,"inspected_file_count":1}}====================
+  // def a
+  //   3
+  // end
+  //
+  // So we need to parse out the actual auto-corrected ruby
+  private onSuccess(document: vscode.TextDocument, stdout: Buffer) {
+    const stringOut = stdout.toString();
+    const autoCorrection = stringOut.match(
+      /^.*\n====================(?:\n|\r\n)([.\s\S]*)/m
+    );
+    if (!autoCorrection) {
+      throw new Error(`Error parsing auto-correction from CLI: ${stringOut}`);
+    }
+    return [
+      new vscode.TextEdit(this.getFullRange(document), autoCorrection.pop()),
+    ];
+  }
+
+  private getFullRange(document: vscode.TextDocument): vscode.Range {
+    return new vscode.Range(
+      new vscode.Position(0, 0),
+      document.lineAt(document.lineCount - 1).range.end
+    );
+  }
+}

--- a/src/rubocopQuickFixProvider.ts
+++ b/src/rubocopQuickFixProvider.ts
@@ -25,7 +25,7 @@ export default class RubocopQuickFixProvider
   // is hovered or when the cursor's position is changed.
   public provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection): vscode.ProviderResult<vscode.CodeAction[]> {
     const fileDiagnostics = this.diag.get(document.uri);
-    if(fileDiagnostics === undefined || fileDiagnostics === null || fileDiagnostics.length == 0) return;
+    if(fileDiagnostics === undefined || fileDiagnostics === null || fileDiagnostics.length == 0) return null;
 
     const appliedDiagnostics = fileDiagnostics.filter((diagnostic) => {
       return undefined !== diagnostic.range.intersection(range)

--- a/src/rubocopQuickFixProvider.ts
+++ b/src/rubocopQuickFixProvider.ts
@@ -71,10 +71,10 @@ export default class RubocopQuickFixProvider
   }
 
   private forceFixingAll(): vscode.CodeAction {
-    const quickFix = new vscode.CodeAction('Force fixing all warnings', vscode.CodeActionKind.QuickFix);
+    const quickFix = new vscode.CodeAction('Fix all warnings', vscode.CodeActionKind.QuickFix);
     quickFix.command = {
       command: 'ruby.rubocop.autocorrect',
-      title: 'Force fixing all warnings',
+      title: 'Fix all warnings',
       arguments: ['-A']
     };
 
@@ -82,10 +82,10 @@ export default class RubocopQuickFixProvider
   }
 
   private fixAllSafely(): vscode.CodeAction {
-    const quickFix = new vscode.CodeAction(`Fix all warnings safely`, vscode.CodeActionKind.QuickFix);
+    const quickFix = new vscode.CodeAction(`Fix all warnings (safely)`, vscode.CodeActionKind.QuickFix);
     quickFix.command = {
       command: 'ruby.rubocop.autocorrect',
-      title: `Fix all warnings safely`
+      title: `Fix all warnings (safely)`
     };
 
     return quickFix;
@@ -112,10 +112,10 @@ export default class RubocopQuickFixProvider
     const correctableMatch = diagnostic.source?.match(correctableDiagnosticRegexp);
     if(correctableMatch === null || correctableMatch === undefined) return null;
 
-    const quickFix = new vscode.CodeAction(`Fix \`${copName}\` in this file`, vscode.CodeActionKind.QuickFix);
+    const quickFix = new vscode.CodeAction(`Fix \`${copName}\``, vscode.CodeActionKind.QuickFix);
     quickFix.command = {
       command: 'ruby.rubocop.autocorrect',
-      title: `Fix \`${copName}\` in this file`,
+      title: `Fix \`${copName}\``,
       arguments: ['-A', '--only', copName]
     };
     quickFix.diagnostics = [diagnostic];
@@ -132,11 +132,11 @@ export default class RubocopQuickFixProvider
 
     if(currentWorkspaceFolder === undefined || currentWorkspaceFolder === null) return null;
 
-    const quickFix = new vscode.CodeAction(`Disable \`${copName}\` for this project`, vscode.CodeActionKind.QuickFix);
+    const quickFix = new vscode.CodeAction(`Disable (project) \`${copName}\``, vscode.CodeActionKind.QuickFix);
     quickFix.diagnostics = [diagnostic];
     quickFix.command = {
       command: 'ruby.rubocop.disableCop',
-      title: `Disable \`${copName}\` in \`.rubocop.yml\``,
+      title: `Disable (project) \`${copName}\` in \`.rubocop.yml\``,
       arguments: [currentWorkspaceFolder, copName]
     };
 
@@ -144,7 +144,7 @@ export default class RubocopQuickFixProvider
   }
 
   private disableCopForFileQuickFix(document: vscode.TextDocument, copName: string, diagnostic: vscode.Diagnostic): vscode.CodeAction {
-    const quickFix = new vscode.CodeAction(`Disable \`${copName}\` for this file`, vscode.CodeActionKind.QuickFix);
+    const quickFix = new vscode.CodeAction(`Disable (file) \`${copName}\``, vscode.CodeActionKind.QuickFix);
 
     const edit = new vscode.WorkspaceEdit();
     const lineCount = document.lineCount;
@@ -173,7 +173,7 @@ export default class RubocopQuickFixProvider
   }
 
   private ignoreCopForLineQuickFix(document: vscode.TextDocument, copName: string, diagnostic: vscode.Diagnostic): vscode.CodeAction | null {
-    const quickFix = new vscode.CodeAction(`Ignore \`${copName}\` for this line`, vscode.CodeActionKind.QuickFix);
+    const quickFix = new vscode.CodeAction(`Ignore (line) \`${copName}\``, vscode.CodeActionKind.QuickFix);
 
     const lineNumber = diagnostic.range.start.line;
     const lineText = document.lineAt(lineNumber).text;

--- a/src/rubocopQuickFixProvider.ts
+++ b/src/rubocopQuickFixProvider.ts
@@ -1,0 +1,180 @@
+import * as vscode from 'vscode';
+
+const initialWhitespaceRegexp = /^\s+/
+const correctableRegexp = /\[Correctable\]\([a-z]+:((\w|\/)+)\)$/;
+// Group 1 is the name of the cop
+const copFromMessageRegexp = /\([a-z]+:((\w|\/)+)\)$/;
+// Group 1 is the code without the comment
+// Group 5 is the comment
+const rubyCommentRegexp = /^[\t ]*([^#"'\r\n]("(\\"|[^"])*"|'(\\'|[^'])*'|[^#\n\r])*)(#([^#\r\n]*))?/
+// Group 2 is the list of cop names
+const rubocopDisableRegexp = /(# )?rubocop:disable (((\w|\/)+)(,\s+((\w|\/)+))*)/
+
+export default class RubocopQuickFixProvider
+  implements vscode.CodeActionProvider
+{
+  private diag: vscode.DiagnosticCollection;
+
+  constructor(diagnostics: vscode.DiagnosticCollection) {
+    this.diag = diagnostics;
+  }
+
+  // This method is called whenever a rubocop warning
+  // is hovered or when the cursor's position is changed.
+  public provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection): vscode.ProviderResult<vscode.CodeAction[]> {
+    const fileDiagnostics = this.diag.get(document.uri);
+    if(fileDiagnostics === undefined || fileDiagnostics === null || fileDiagnostics.length == 0) return;
+
+    const appliedDiagnostics = fileDiagnostics.filter((diagnostic) => {
+      return undefined !== diagnostic.range.intersection(range)
+    })
+
+    let quickFixes: vscode.CodeAction[] = [];
+
+    appliedDiagnostics.forEach((diagnostic) => {
+      quickFixes = quickFixes.concat(this.createQuickFixes(document, diagnostic));
+    })
+
+    return quickFixes;
+  }
+
+  private createQuickFixes(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): vscode.CodeAction[] {
+    const quickFixes = []
+    const copName = this.extractCopName(diagnostic);
+
+    const autocorrectQuickFix = this.autocorrectCopInFile(copName, diagnostic);
+    if(autocorrectQuickFix !== null) quickFixes.push(autocorrectQuickFix);
+
+    quickFixes.push(this.ignoreCopForLineQuickFix(document, copName, diagnostic));
+
+    const disableCopInRubocopYaml = this.disableCopInRubocopYaml(document, copName, diagnostic);
+    if(disableCopInRubocopYaml !== null) quickFixes.push(disableCopInRubocopYaml);
+
+    quickFixes.push(this.showCopDocumentation(copName, diagnostic));
+    quickFixes.push(this.forceFixingAll(diagnostic));
+    quickFixes.push(this.fixAllSafely(diagnostic));
+
+    return quickFixes;
+  }
+
+  private forceFixingAll(diagnostic: vscode.Diagnostic): vscode.CodeAction {
+    if(diagnostic.source?.match(correctableRegexp) === null) return null;
+
+    const quickFix = new vscode.CodeAction('Force fixing all warnings', vscode.CodeActionKind.QuickFix);
+    quickFix.command = {
+      command: 'ruby.rubocop.autocorrect',
+      title: 'Force fixing all warnings',
+      arguments: ['-A']
+    };
+
+    return quickFix;
+  }
+
+  private fixAllSafely(diagnostic: vscode.Diagnostic): vscode.CodeAction {
+    if(diagnostic.source?.match(correctableRegexp) === null) return null;
+
+    const quickFix = new vscode.CodeAction(`Fix all warnings safely`, vscode.CodeActionKind.QuickFix);
+    quickFix.command = {
+      command: 'ruby.rubocop.autocorrect',
+      title: `Fix all warnings safely`
+    };
+
+    return quickFix;
+  }
+
+  private showCopDocumentation(copName: string, diagnostic: vscode.Diagnostic): vscode.CodeAction {
+    const copNameArray = copName.split('/');
+    const copDepartment = copNameArray[0].toLowerCase();
+    const copId = copNameArray[1].toLowerCase();
+    const docsUri = `https://docs.rubocop.org/rubocop/cops_${copDepartment}.html#${copDepartment}${copId}`;
+
+    const quickFix = new vscode.CodeAction(`Show documentation for \`${copName}\``, vscode.CodeActionKind.QuickFix);
+    quickFix.command = {
+      command: 'vscode.open',
+      title: `Show documentation for \`${copName}\``,
+      arguments: [docsUri]
+    };
+    quickFix.diagnostics = [diagnostic];
+
+    return quickFix;
+  }
+
+  private autocorrectCopInFile(copName: string, diagnostic: vscode.Diagnostic): vscode.CodeAction | null {
+    if(diagnostic.source?.match(correctableRegexp) === null) return null;
+
+    const quickFix = new vscode.CodeAction(`Fix \`${copName}\` in this file`, vscode.CodeActionKind.QuickFix);
+    quickFix.command = {
+      command: 'ruby.rubocop.autocorrect',
+      title: `Fix \`${copName}\` in this file`,
+      arguments: ['-A', '--only', copName]
+    };
+    quickFix.diagnostics = [diagnostic];
+
+    return quickFix;
+  }
+
+  private disableCopInRubocopYaml(document: vscode.TextDocument, copName: string, diagnostic: vscode.Diagnostic): vscode.CodeAction | null {
+    if(vscode.workspace.workspaceFolders === undefined) return null;
+
+    const currentWorkspaceFolder = vscode.workspace.workspaceFolders.find((workspaceFolder) => {
+      return document.uri.path.includes(workspaceFolder.uri.path);
+    })
+
+    if(currentWorkspaceFolder === undefined) return null;
+
+    const quickFix = new vscode.CodeAction(`Disable \`${copName}\` for this project`, vscode.CodeActionKind.QuickFix);
+    quickFix.diagnostics = [diagnostic];
+    quickFix.command = {
+      command: 'ruby.rubocop.disableCop',
+      title: `Disable \`${copName}\` in \`.rubocop.yml\``,
+      arguments: [currentWorkspaceFolder, copName]
+    };
+
+    return quickFix;
+  }
+
+  private ignoreCopForLineQuickFix(document: vscode.TextDocument, copName: string, diagnostic: vscode.Diagnostic): vscode.CodeAction {
+    const quickFix = new vscode.CodeAction(`Ignore \`${copName}\` for this line`, vscode.CodeActionKind.QuickFix);
+
+    const lineNumber = diagnostic.range.start.line;
+    const lineText = document.lineAt(lineNumber).text;
+    let newCommentStartCharacter = lineText.length;
+    let newCommentText = ` # rubocop:disable ${copName}`;
+
+    const initialWhitespace = lineText.match(initialWhitespaceRegexp) || '';
+    const existingCommentMatch = lineText.match(rubyCommentRegexp);
+    const existingCommentText = existingCommentMatch[5];
+    const codeWithoutComment = `${initialWhitespace}${existingCommentMatch[1]}`;
+
+    if(existingCommentText !== undefined) {
+      newCommentStartCharacter = 0
+      const rubocopDisableMatch = existingCommentText.match(rubocopDisableRegexp);
+
+      if(rubocopDisableMatch !== null) {
+        newCommentText = `${codeWithoutComment}${rubocopDisableMatch[0]}, ${copName}`;
+      } else {
+        newCommentText = `${codeWithoutComment}${newCommentText.substring(1)}`;
+      }
+    }
+
+    const edit = new vscode.WorkspaceEdit();
+    const editRange = new vscode.Range(
+      new vscode.Position(lineNumber, newCommentStartCharacter),
+      new vscode.Position(lineNumber, newCommentStartCharacter + newCommentText.length)
+    );
+
+    edit.replace(document.uri, editRange, newCommentText);
+    quickFix.edit = edit;
+    quickFix.command = { command: 'ruby.rubocop', title: 'Lint the file with Rubocop' };
+    quickFix.diagnostics = [diagnostic]
+
+    return quickFix;
+  }
+
+  private extractCopName(diagnostic: vscode.Diagnostic): string | null {
+    const matches = diagnostic.source?.match(copFromMessageRegexp);
+    if(matches === null) return null;
+
+    return matches[1];
+  }
+}

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -13,18 +13,23 @@ if something and other and 4
   return nil
 end
 
-{
-      car: 3, # some comment
+{ # some comment
+      car: 3,
     boot: 56, bonnet: 10
 }
+`;
 
-def someMethod(    arg )
-  if arg
-    return arg
-  end
+export const rubyFileWithDisabledCopForLine = `
+if something and other and 4 # rubocop:disable Style/IfUnlessModifier
+  return nil
+end
+`;
 
-  return :default
-  end                    
+export const rubyFileWithDisabledCopForFile = `# rubocop:disable Style/IfUnlessModifier
+if something and other and 4
+  return nil
+end
+# rubocop:enable Style/IfUnlessModifier
 `;
 
 export const jsFile = `

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -8,6 +8,25 @@ export const rubyFileWithWarnings = `
     end                    
 `;
 
+export const rubyFileToQuickFix = `
+if something and other and 4
+  return nil
+end
+
+{
+      car: 3, # some comment
+    boot: 56, bonnet: 10
+}
+
+def someMethod(    arg )
+  if arg
+    return arg
+  end
+
+  return :default
+  end                    
+`;
+
 export const jsFile = `
   function printHello() {
     console.log("Hi i'm JavaScript!")

--- a/test/rubocopQuickFixProvider.test.ts
+++ b/test/rubocopQuickFixProvider.test.ts
@@ -82,7 +82,7 @@ describe('RubocopQuickFixProvider', () => {
       });
 
       it('ignores `Lint/Void` for line', () => {
-        expect(quickFixes[0].title).to.contain('Ignore `Lint/Void` for this line');
+        expect(quickFixes[0].title).to.equal('Ignore (line) `Lint/Void`');
 
         expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop');
         expect(quickFixes[0].command.title).to.be.equal('Lint the file with Rubocop');
@@ -98,7 +98,7 @@ describe('RubocopQuickFixProvider', () => {
       });
 
       it('disables `Lint/Void` for file', () => {
-        expect(quickFixes[1].title).to.contain('Disable `Lint/Void` for this file');
+        expect(quickFixes[1].title).to.be.equal('Disable (file) `Lint/Void`');
 
         expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
         expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
@@ -168,15 +168,15 @@ describe('RubocopQuickFixProvider', () => {
       });
 
       it('fixes `Layout/FirstHashElementIndentation` in file', () => {
-        expect(quickFixes[0].title).to.contain('Fix `Layout/FirstHashElementIndentation` in this file');
+        expect(quickFixes[0].title).to.be.equal('Fix `Layout/FirstHashElementIndentation`');
         expect(quickFixes[0].edit).to.be.equal(undefined);
         expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop.autocorrect');
-        expect(quickFixes[0].command.title).to.be.equal('Fix `Layout/FirstHashElementIndentation` in this file');
+        expect(quickFixes[0].command.title).to.be.equal('Fix `Layout/FirstHashElementIndentation`');
         expect(JSON.stringify(quickFixes[0].command.arguments)).to.be.equal(JSON.stringify(['-A', '--only', 'Layout/FirstHashElementIndentation']));
       });
 
       it('ignores `Layout/FirstHashElementIndentation` for line', () => {
-        expect(quickFixes[1].title).to.contain('Ignore `Layout/FirstHashElementIndentation` for this line');
+        expect(quickFixes[1].title).to.be.equal('Ignore (line) `Layout/FirstHashElementIndentation`');
 
         expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
         expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
@@ -192,7 +192,7 @@ describe('RubocopQuickFixProvider', () => {
       });
 
       it('disables `Layout/FirstHashElementIndentation` for file', () => {
-        expect(quickFixes[2].title).to.contain('Disable `Layout/FirstHashElementIndentation` for this file');
+        expect(quickFixes[2].title).to.be.equal('Disable (file) `Layout/FirstHashElementIndentation`');
 
         expect(quickFixes[2].command.command).to.be.equal('ruby.rubocop');
         expect(quickFixes[2].command.title).to.be.equal('Lint the file with Rubocop');
@@ -222,21 +222,21 @@ describe('RubocopQuickFixProvider', () => {
       });
 
       it('forces fixing all', () => {
-        expect(quickFixes[4].title).to.contain('Force fixing all warnings')
+        expect(quickFixes[4].title).to.be.equal('Fix all warnings')
         expect(quickFixes[4].edit).to.be.equal(undefined);
 
         expect(quickFixes[4].command.command).to.be.equal('ruby.rubocop.autocorrect');
-        expect(quickFixes[4].command.title).to.be.equal('Force fixing all warnings');
+        expect(quickFixes[4].command.title).to.be.equal('Fix all warnings');
         expect(quickFixes[4].command.arguments.length).to.be.equal(1);
         expect(quickFixes[4].command.arguments[0]).to.be.equal('-A');
       });
 
       it('fixes all safely', () => {
-        expect(quickFixes[5].title).to.contain('Fix all warnings safely')
+        expect(quickFixes[5].title).to.be.equal('Fix all warnings (safely)')
         expect(quickFixes[5].edit).to.be.equal(undefined);
 
         expect(quickFixes[5].command.command).to.be.equal('ruby.rubocop.autocorrect');
-        expect(quickFixes[5].command.title).to.be.equal('Fix all warnings safely');
+        expect(quickFixes[5].command.title).to.be.equal('Fix all warnings (safely)');
         expect(quickFixes[5].command.arguments).to.be.equal(undefined);
       });
     });
@@ -271,7 +271,7 @@ describe('RubocopQuickFixProvider', () => {
       expect(quickFixes).to.be.instanceOf(Array);
       expect(quickFixes.length).to.be.equal(6);
 
-      expect(quickFixes[1].title).to.contain('Ignore `Style/AndOr` for this line');
+      expect(quickFixes[1].title).to.be.equal('Ignore (line) `Style/AndOr`');
 
       expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
       expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
@@ -318,7 +318,7 @@ describe('RubocopQuickFixProvider', () => {
       expect(quickFixes).to.be.instanceOf(Array);
       expect(quickFixes.length).to.be.equal(6);
 
-      expect(quickFixes[2].title).to.contain('Disable `Style/AndOr` for this file');
+      expect(quickFixes[2].title).to.be.equal('Disable (file) `Style/AndOr`' );
 
       expect(quickFixes[2].command.command).to.be.equal('ruby.rubocop');
       expect(quickFixes[2].command.title).to.be.equal('Lint the file with Rubocop');

--- a/test/rubocopQuickFixProvider.test.ts
+++ b/test/rubocopQuickFixProvider.test.ts
@@ -1,0 +1,172 @@
+import { expect } from 'chai';
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+
+import * as helper from './helper';
+import * as fixtures from './fixtures';
+import RubocopQuickFixProvider from '../src/rubocopQuickFixProvider';
+
+describe('RubocopQuickFixProvider', () => {
+  let instance: RubocopQuickFixProvider;
+  let diagnostics: vscode.DiagnosticCollection;
+
+  beforeEach(() => {
+    diagnostics = vscode.languages.createDiagnosticCollection();
+    instance = new RubocopQuickFixProvider(diagnostics);
+  });
+
+  describe('initialization', () => {
+    describe('.diag', () => {
+      it('is set to the provided DiagnosticCollection', () => {
+        expect(instance).to.have.property('diag', diagnostics);
+      });
+    });
+  });
+
+  describe('provideCodeActions', () => {
+    it('does not generate quick fixes for code without a diagnostic', async function () {
+      this.timeout(5000);
+      await helper.closeAllEditors();
+
+      const filePath = helper.createTempFile(
+        'file_to_quick_fix.rb',
+        fixtures.rubyFileToQuickFix
+      );
+      const editor = await helper.openFile(filePath);
+      const range = new vscode.Range(new vscode.Position(4, 0), new vscode.Position(4, 0));
+      const quickFixes = instance.provideCodeActions(editor.document, range);
+      expect(quickFixes).to.be.equal(null);
+
+      fs.unlinkSync(filePath);
+    });
+
+    it('generates quick fixes for code with an uncorrectable diagnostic', async function () {
+      this.timeout(5000);
+      await helper.closeAllEditors();
+
+      const filePath = helper.createTempFile(
+        'file_to_quick_fix.rb',
+        fixtures.rubyFileToQuickFix
+      );
+      const editor = await helper.openFile(filePath);
+      vscode.commands.executeCommand('ruby.rubocop', () => {
+        let fileEdits: vscode.TextEdit[];
+
+        const range = new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 0));
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        const quickFixes: vscode.CodeAction[] = instance.provideCodeActions(editor.document, range);
+        expect(quickFixes).to.be.instanceOf(Array);
+        expect(quickFixes.length).to.be.equal(4);
+
+        expect(quickFixes[0].title).to.contain('Ignore `Lint/Void` for this line');
+        expect(quickFixes[0].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+        fileEdits = quickFixes[0].edit.get(editor.document.uri);
+        expect(fileEdits.length).to.be.equal(1);
+        expect(fileEdits[0].newText).to.be.equal('{ # rubocop:disable Lint/Void');
+        expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop');
+        expect(quickFixes[0].command.title).to.be.equal('Lint the file with Rubocop');
+        expect(quickFixes[0].command.arguments).to.be.equal(undefined);
+
+        expect(quickFixes[1].title).to.contain('Disable `Lint/Void` for this file');
+        fileEdits = quickFixes[1].edit.get(editor.document.uri);
+        expect(fileEdits.length).to.be.equal(2);
+        expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Lint/Void');
+        expect(fileEdits[1].newText).to.be.equal('# rubocop:enable Lint/Void');
+        expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
+        expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
+        expect(quickFixes[1].command.arguments).to.be.equal(undefined);
+
+        expect(quickFixes[2].title).to.contain('Disable `Lint/Void` for this project');
+        expect(quickFixes[2].edit).to.be.equal(null);
+        expect(quickFixes[2].command.command).to.be.equal('ruby.rubocop.disableCop');
+        expect(quickFixes[2].command.title).to.be.equal('Disable `Lint/Void` in `.rubocop.yml`');
+        expect(quickFixes[2].command.arguments).to.be.equal([vscode.workspace.workspaceFolders[0], 'Lint/Void']);
+
+        expect(quickFixes[3].title).to.contain('Show documentation for `Lint/Void`');
+        expect(quickFixes[3].edit).to.be.equal(null);
+        expect(quickFixes[3].command.command).to.be.equal('vscode.open');
+        expect(quickFixes[3].command.title).to.be.equal('Show documentation for `Lint/Void`');
+        expect(quickFixes[3].command.arguments).to.be.equal(['https://docs.rubocop.org/rubocop/cops_lint.html#lintvoid']);
+
+        fs.unlinkSync(filePath);
+      })
+    });
+
+    it('generates quick fixes for code with a correctable diagnostic', async function () {
+      this.timeout(5000);
+      await helper.closeAllEditors();
+
+      const filePath = helper.createTempFile(
+        'file_to_quick_fix.rb',
+        fixtures.rubyFileToQuickFix
+      );
+      const editor = await helper.openFile(filePath);
+      vscode.commands.executeCommand('ruby.rubocop', () => {
+        let fileEdits: vscode.TextEdit[];
+
+        const range = new vscode.Range(new vscode.Position(7, 7), new vscode.Position(7, 8));
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        const quickFixes: vscode.CodeAction[] = instance.provideCodeActions(editor.document, range);
+        expect(quickFixes).to.be.instanceOf(Array);
+        expect(quickFixes.length).to.be.equal(7);
+
+        expect(quickFixes[0].title).to.contain('Fix `Layout/FirstHashElementIndentation` in this file');
+        expect(quickFixes[0].edit).to.be.equal(null);
+        expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop.autocorrect');
+        expect(quickFixes[0].command.title).to.be.equal('Fix `Layout/FirstHashElementIndentation` in this file');
+        expect(quickFixes[0].command.arguments).to.be.equal(['-A', '--only', 'Layout/FirstHashElementIndentation']);
+
+        expect(quickFixes[1].title).to.contain('Ignore `Layout/FirstHashElementIndentation` for this line');
+        expect(quickFixes[1].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+        fileEdits = quickFixes[1].edit.get(editor.document.uri);
+        expect(fileEdits.length).to.be.equal(1);
+        expect(fileEdits[0].newText).to.be.equal('      car: 3, # rubocop:disable Layout/FirstHashElementIndentation');
+        expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
+        expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
+        expect(quickFixes[1].command.arguments).to.be.equal(undefined);
+
+        expect(quickFixes[2].title).to.contain('Disable `Layout/FirstHashElementIndentation` for this file');
+        fileEdits = quickFixes[2].edit.get(editor.document.uri);
+        expect(fileEdits.length).to.be.equal(2);
+        expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Layout/FirstHashElementIndentation');
+        expect(fileEdits[1].newText).to.be.equal('# rubocop:enable Layout/FirstHashElementIndentation');
+        expect(quickFixes[2].command.command).to.be.equal('ruby.rubocop');
+        expect(quickFixes[2].command.title).to.be.equal('Lint the file with Rubocop');
+        expect(quickFixes[2].command.arguments).to.be.equal(undefined);
+
+        expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
+        expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
+        expect(quickFixes[1].command.arguments).to.be.equal(undefined);
+
+        expect(quickFixes[3].title).to.contain('Disable `Layout/FirstHashElementIndentation` for this project');
+        expect(quickFixes[3].edit).to.be.equal(null);
+        expect(quickFixes[3].command.command).to.be.equal('ruby.rubocop.disableCop');
+        expect(quickFixes[3].command.title).to.be.equal('Disable `Layout/FirstHashElementIndentation` in `.rubocop.yml`');
+        expect(quickFixes[3].command.arguments).to.be.equal([vscode.workspace.workspaceFolders[0], 'Layout/FirstHashElementIndentation']);
+
+        expect(quickFixes[4].title).to.contain('Show documentation for `Layout/FirstHashElementIndentation`');
+        expect(quickFixes[4].edit).to.be.equal(null);
+        expect(quickFixes[4].command.command).to.be.equal('vscode.open');
+        expect(quickFixes[4].command.title).to.be.equal('Show documentation for `Layout/FirstHashElementIndentation`');
+        expect(quickFixes[4].command.arguments).to.be.equal(['https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirsthashelementindentation']);
+
+        expect(quickFixes[5].title).to.contain('Force fixing all warnings')
+        expect(quickFixes[5].edit).to.be.equal(null);
+        expect(quickFixes[5].command.command).to.be.equal('ruby.rubocop.autocorrect');
+        expect(quickFixes[5].command.title).to.be.equal('Force fixing all warnings');
+        expect(quickFixes[5].command.arguments).to.be.equal(['-A']);
+
+        expect(quickFixes[6].title).to.contain('Fix all warnings safely')
+        expect(quickFixes[6].edit).to.be.equal(null);
+        expect(quickFixes[6].command.command).to.be.equal('ruby.rubocop.autocorrect');
+        expect(quickFixes[6].command.title).to.be.equal('Fix all warnings safely');
+        expect(quickFixes[6].command.arguments).to.be.equal(null);
+
+        fs.unlinkSync(filePath);
+      });
+
+    });
+  });
+});

--- a/test/rubocopQuickFixProvider.test.ts
+++ b/test/rubocopQuickFixProvider.test.ts
@@ -40,182 +40,205 @@ describe('RubocopQuickFixProvider', () => {
       fs.unlinkSync(filePath);
     });
 
-    it('generates quick fixes for code with an uncorrectable diagnostic', async function () {
-      this.timeout(5000);
-      await helper.closeAllEditors();
+    describe('generates quick fixes for code with an uncorrectable diagnostic', () => {
+      let fileEdits: vscode.TextEdit[];
+      let range: vscode.Range;
+      let quickFixes: vscode.CodeAction[];
+      let editor: vscode.TextEditor;
+      let filePath: string;
 
-      const filePath = helper.createTempFile(
-        'file_to_quick_fix.rb',
-        fixtures.rubyFileToQuickFix
-      );
-      const editor = await helper.openFile(filePath);
+      beforeEach(async function() {
+        this.timeout(5000);
+        await helper.closeAllEditors();
 
-      const diagnostic = new vscode.Diagnostic(
-        new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 0)),
+        filePath = helper.createTempFile(
+          'file_to_quick_fix.rb',
+          fixtures.rubyFileToQuickFix
+        );
+        editor = await helper.openFile(filePath);
+
+        const diagnostic = new vscode.Diagnostic(
+          new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 0)),
 `Literal \`{
       car: 3, # some comment
     boot: 56, bonnet: 10
 }\` used in void context.`,
-        vscode.DiagnosticSeverity.Warning
-      );
-      diagnostic.source = '(warning:Lint/Void)';
-      diagnostics.set(editor.document.uri, [diagnostic]);
+          vscode.DiagnosticSeverity.Warning
+        );
+        diagnostic.source = '(warning:Lint/Void)';
+        diagnostics.set(editor.document.uri, [diagnostic]);
 
-      let fileEdits: vscode.TextEdit[];
-      let range: vscode.Range;
+        range = new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 0));
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        quickFixes = instance.provideCodeActions(editor.document, range);
 
-      range = new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 0));
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
-      const quickFixes: vscode.CodeAction[] = instance.provideCodeActions(editor.document, range);
+        expect(quickFixes).to.be.instanceOf(Array);
+        expect(quickFixes.length).to.be.equal(3);
+      });
 
-      expect(quickFixes).to.be.instanceOf(Array);
-      expect(quickFixes.length).to.be.equal(3);
+      afterEach(() => {
+        fs.unlinkSync(filePath);
+      });
 
-      // Ignore for line
-      expect(quickFixes[0].title).to.contain('Ignore `Lint/Void` for this line');
+      it('ignores `Lint/Void` for line', () => {
+        expect(quickFixes[0].title).to.contain('Ignore `Lint/Void` for this line');
 
-      expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop');
-      expect(quickFixes[0].command.title).to.be.equal('Lint the file with Rubocop');
-      expect(quickFixes[0].command.arguments).to.be.equal(undefined);
+        expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop');
+        expect(quickFixes[0].command.title).to.be.equal('Lint the file with Rubocop');
+        expect(quickFixes[0].command.arguments).to.be.equal(undefined);
 
-      expect(quickFixes[0].edit).to.be.instanceOf(vscode.WorkspaceEdit);
-      fileEdits = quickFixes[0].edit.get(editor.document.uri);
-      expect(fileEdits.length).to.be.equal(1);
+        expect(quickFixes[0].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+        fileEdits = quickFixes[0].edit.get(editor.document.uri);
+        expect(fileEdits.length).to.be.equal(1);
 
-      expect(fileEdits[0].newText).to.be.equal('{ # rubocop:disable Lint/Void');
-      range = new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 29));
-      expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
+        expect(fileEdits[0].newText).to.be.equal('{ # rubocop:disable Lint/Void');
+        range = new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 29));
+        expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
+      });
 
-      // Disable for file
-      expect(quickFixes[1].title).to.contain('Disable `Lint/Void` for this file');
+      it('disables `Lint/Void` for file', () => {
+        expect(quickFixes[1].title).to.contain('Disable `Lint/Void` for this file');
 
-      expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
-      expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
-      expect(quickFixes[1].command.arguments).to.be.equal(undefined);
+        expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
+        expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
+        expect(quickFixes[1].command.arguments).to.be.equal(undefined);
 
-      expect(quickFixes[1].edit).to.be.instanceOf(vscode.WorkspaceEdit);
-      fileEdits = quickFixes[1].edit.get(editor.document.uri);
-      expect(fileEdits.length).to.be.equal(2);
+        expect(quickFixes[1].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+        fileEdits = quickFixes[1].edit.get(editor.document.uri);
+        expect(fileEdits.length).to.be.equal(2);
 
-      expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Lint/Void\n');
-      range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
-      expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
+        expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Lint/Void\n');
+        range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+        expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
 
-      expect(fileEdits[1].newText).to.be.equal('\n# rubocop:enable Lint/Void\n');
-      range = new vscode.Range(new vscode.Position(10, 0), new vscode.Position(10, 0));
-      expect(JSON.stringify(fileEdits[1].range)).to.be.equal(JSON.stringify(range));
+        expect(fileEdits[1].newText).to.be.equal('\n# rubocop:enable Lint/Void\n');
+        range = new vscode.Range(new vscode.Position(10, 0), new vscode.Position(10, 0));
+        expect(JSON.stringify(fileEdits[1].range)).to.be.equal(JSON.stringify(range));
+      });
 
-      // Show documentation
-      expect(quickFixes[2].title).to.contain('Show documentation for `Lint/Void`');
-      expect(quickFixes[2].edit).to.be.equal(undefined);
+      it('shows the documentation for `Lint/Void`', () => {
+        expect(quickFixes[2].title).to.contain('Show documentation for `Lint/Void`');
+        expect(quickFixes[2].edit).to.be.equal(undefined);
 
-      expect(quickFixes[2].command.command).to.be.equal('vscode.open');
-      expect(quickFixes[2].command.title).to.be.equal('Show documentation for `Lint/Void`');
-      expect(quickFixes[2].command.arguments.length).to.be.equal(1);
-      expect(quickFixes[2].command.arguments[0]).to.be.equal('https://docs.rubocop.org/rubocop/cops_lint.html#lintvoid');
-
-      fs.unlinkSync(filePath);
+        expect(quickFixes[2].command.command).to.be.equal('vscode.open');
+        expect(quickFixes[2].command.title).to.be.equal('Show documentation for `Lint/Void`');
+        expect(quickFixes[2].command.arguments.length).to.be.equal(1);
+        expect(quickFixes[2].command.arguments[0]).to.be.equal('https://docs.rubocop.org/rubocop/cops_lint.html#lintvoid');
+      });
     });
 
-    it('generates quick fixes for code with a correctable diagnostic', async function () {
-      this.timeout(5000);
-      await helper.closeAllEditors();
-
-      const filePath = helper.createTempFile(
-        'file_to_quick_fix.rb',
-        fixtures.rubyFileToQuickFix
-      );
-      const editor = await helper.openFile(filePath);
-
-      await helper.sleep(500);
-      const diagnostic = new vscode.Diagnostic(
-        new vscode.Range(new vscode.Position(6, 7), new vscode.Position(6, 12)),
-        'Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.',
-        vscode.DiagnosticSeverity.Warning
-      );
-      diagnostic.source = '[Correctable](convention:Layout/FirstHashElementIndentation)';
-      diagnostics.set(editor.document.uri, [diagnostic]);
-
+    describe('generates quick fixes for code with a correctable diagnostic', () => {
       let fileEdits: vscode.TextEdit[];
       let range: vscode.Range;
+      let quickFixes: vscode.CodeAction[];
+      let editor: vscode.TextEditor;
+      let filePath: string;
 
-      range = new vscode.Range(new vscode.Position(6, 7), new vscode.Position(6, 8));
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
-      const quickFixes: vscode.CodeAction[] = instance.provideCodeActions(editor.document, range);
+      beforeEach(async function() {
+        this.timeout(5000);
+        await helper.closeAllEditors();
 
-      expect(quickFixes).to.be.instanceOf(Array);
-      expect(quickFixes.length).to.be.equal(6);
+        filePath = helper.createTempFile(
+          'file_to_quick_fix.rb',
+          fixtures.rubyFileToQuickFix
+        );
+        editor = await helper.openFile(filePath);
 
-      // ==== Fix in file ====
-      expect(quickFixes[0].title).to.contain('Fix `Layout/FirstHashElementIndentation` in this file');
-      expect(quickFixes[0].edit).to.be.equal(undefined);
-      expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop.autocorrect');
-      expect(quickFixes[0].command.title).to.be.equal('Fix `Layout/FirstHashElementIndentation` in this file');
-      expect(JSON.stringify(quickFixes[0].command.arguments)).to.be.equal(JSON.stringify(['-A', '--only', 'Layout/FirstHashElementIndentation']));
+        await helper.sleep(500);
+        const diagnostic = new vscode.Diagnostic(
+          new vscode.Range(new vscode.Position(6, 7), new vscode.Position(6, 12)),
+          'Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.',
+          vscode.DiagnosticSeverity.Warning
+        );
+        diagnostic.source = '[Correctable](convention:Layout/FirstHashElementIndentation)';
+        diagnostics.set(editor.document.uri, [diagnostic]);
 
-      // ==== Ignore for line ====
-      expect(quickFixes[1].title).to.contain('Ignore `Layout/FirstHashElementIndentation` for this line');
+        range = new vscode.Range(new vscode.Position(6, 7), new vscode.Position(6, 8));
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        quickFixes = instance.provideCodeActions(editor.document, range);
 
-      expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
-      expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
-      expect(quickFixes[1].command.arguments).to.be.equal(undefined);
+        expect(quickFixes).to.be.instanceOf(Array);
+        expect(quickFixes.length).to.be.equal(6);
+      });
 
-      expect(quickFixes[1].edit).to.be.instanceOf(vscode.WorkspaceEdit);
-      fileEdits = quickFixes[1].edit.get(editor.document.uri);
-      expect(fileEdits.length).to.be.equal(1);
+      afterEach(() => {
+        fs.unlinkSync(filePath);
+      });
 
-      expect(fileEdits[0].newText).to.be.equal(' # rubocop:disable Layout/FirstHashElementIndentation');
-      range = new vscode.Range(new vscode.Position(6, 13), new vscode.Position(6, 66));
-      expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
+      it('fixes `Layout/FirstHashElementIndentation` in file', () => {
+        expect(quickFixes[0].title).to.contain('Fix `Layout/FirstHashElementIndentation` in this file');
+        expect(quickFixes[0].edit).to.be.equal(undefined);
+        expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop.autocorrect');
+        expect(quickFixes[0].command.title).to.be.equal('Fix `Layout/FirstHashElementIndentation` in this file');
+        expect(JSON.stringify(quickFixes[0].command.arguments)).to.be.equal(JSON.stringify(['-A', '--only', 'Layout/FirstHashElementIndentation']));
+      });
 
-      // ==== Disable for file ====
-      expect(quickFixes[2].title).to.contain('Disable `Layout/FirstHashElementIndentation` for this file');
+      it('ignores `Layout/FirstHashElementIndentation` for line', () => {
+        expect(quickFixes[1].title).to.contain('Ignore `Layout/FirstHashElementIndentation` for this line');
 
-      expect(quickFixes[2].command.command).to.be.equal('ruby.rubocop');
-      expect(quickFixes[2].command.title).to.be.equal('Lint the file with Rubocop');
-      expect(quickFixes[2].command.arguments).to.be.equal(undefined);
+        expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
+        expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
+        expect(quickFixes[1].command.arguments).to.be.equal(undefined);
 
-      expect(quickFixes[2].edit).to.be.instanceOf(vscode.WorkspaceEdit);
-      fileEdits = quickFixes[2].edit.get(editor.document.uri);
-      expect(fileEdits.length).to.be.equal(2);
+        expect(quickFixes[1].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+        fileEdits = quickFixes[1].edit.get(editor.document.uri);
+        expect(fileEdits.length).to.be.equal(1);
 
-      expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Layout/FirstHashElementIndentation\n');
-      range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
-      expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
+        expect(fileEdits[0].newText).to.be.equal(' # rubocop:disable Layout/FirstHashElementIndentation');
+        range = new vscode.Range(new vscode.Position(6, 13), new vscode.Position(6, 66));
+        expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
+      });
 
-      expect(fileEdits[1].newText).to.be.equal('\n# rubocop:enable Layout/FirstHashElementIndentation\n');
-      range = new vscode.Range(new vscode.Position(10, 0), new vscode.Position(10, 0));
-      expect(JSON.stringify(fileEdits[1].range)).to.be.equal(JSON.stringify(range));
+      it('disables `Layout/FirstHashElementIndentation` for file', () => {
+        expect(quickFixes[2].title).to.contain('Disable `Layout/FirstHashElementIndentation` for this file');
 
-      // ==== Show documentation ====
-      expect(quickFixes[3].title).to.contain('Show documentation for `Layout/FirstHashElementIndentation`');
-      expect(quickFixes[3].edit).to.be.equal(undefined);
+        expect(quickFixes[2].command.command).to.be.equal('ruby.rubocop');
+        expect(quickFixes[2].command.title).to.be.equal('Lint the file with Rubocop');
+        expect(quickFixes[2].command.arguments).to.be.equal(undefined);
 
-      expect(quickFixes[3].command.command).to.be.equal('vscode.open');
-      expect(quickFixes[3].command.title).to.be.equal('Show documentation for `Layout/FirstHashElementIndentation`');
-      expect(quickFixes[3].command.arguments.length).to.be.equal(1);
-      expect(quickFixes[3].command.arguments[0]).to.be.equal('https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirsthashelementindentation');
+        expect(quickFixes[2].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+        fileEdits = quickFixes[2].edit.get(editor.document.uri);
+        expect(fileEdits.length).to.be.equal(2);
 
-      // ==== Force fixing ====
-      expect(quickFixes[4].title).to.contain('Force fixing all warnings')
-      expect(quickFixes[4].edit).to.be.equal(undefined);
+        expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Layout/FirstHashElementIndentation\n');
+        range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+        expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
 
-      expect(quickFixes[4].command.command).to.be.equal('ruby.rubocop.autocorrect');
-      expect(quickFixes[4].command.title).to.be.equal('Force fixing all warnings');
-      expect(quickFixes[4].command.arguments.length).to.be.equal(1);
-      expect(quickFixes[4].command.arguments[0]).to.be.equal('-A');
+        expect(fileEdits[1].newText).to.be.equal('\n# rubocop:enable Layout/FirstHashElementIndentation\n');
+        range = new vscode.Range(new vscode.Position(10, 0), new vscode.Position(10, 0));
+        expect(JSON.stringify(fileEdits[1].range)).to.be.equal(JSON.stringify(range));
+      });
 
-      // ==== Fix all safely ====
-      expect(quickFixes[5].title).to.contain('Fix all warnings safely')
-      expect(quickFixes[5].edit).to.be.equal(undefined);
+      it('shows the documentation for `Layout/FirstHashElementIndentation`', () => {
+        expect(quickFixes[3].title).to.contain('Show documentation for `Layout/FirstHashElementIndentation`');
+        expect(quickFixes[3].edit).to.be.equal(undefined);
 
-      expect(quickFixes[5].command.command).to.be.equal('ruby.rubocop.autocorrect');
-      expect(quickFixes[5].command.title).to.be.equal('Fix all warnings safely');
-      expect(quickFixes[5].command.arguments).to.be.equal(undefined);
+        expect(quickFixes[3].command.command).to.be.equal('vscode.open');
+        expect(quickFixes[3].command.title).to.be.equal('Show documentation for `Layout/FirstHashElementIndentation`');
+        expect(quickFixes[3].command.arguments.length).to.be.equal(1);
+        expect(quickFixes[3].command.arguments[0]).to.be.equal('https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirsthashelementindentation');
+      });
 
-      fs.unlinkSync(filePath);
+      it('forces fixing all', () => {
+        expect(quickFixes[4].title).to.contain('Force fixing all warnings')
+        expect(quickFixes[4].edit).to.be.equal(undefined);
+
+        expect(quickFixes[4].command.command).to.be.equal('ruby.rubocop.autocorrect');
+        expect(quickFixes[4].command.title).to.be.equal('Force fixing all warnings');
+        expect(quickFixes[4].command.arguments.length).to.be.equal(1);
+        expect(quickFixes[4].command.arguments[0]).to.be.equal('-A');
+      });
+
+      it('fixes all safely', () => {
+        expect(quickFixes[5].title).to.contain('Fix all warnings safely')
+        expect(quickFixes[5].edit).to.be.equal(undefined);
+
+        expect(quickFixes[5].command.command).to.be.equal('ruby.rubocop.autocorrect');
+        expect(quickFixes[5].command.title).to.be.equal('Fix all warnings safely');
+        expect(quickFixes[5].command.arguments).to.be.equal(undefined);
+      });
     });
   });
 });

--- a/test/rubocopQuickFixProvider.test.ts
+++ b/test/rubocopQuickFixProvider.test.ts
@@ -49,48 +49,73 @@ describe('RubocopQuickFixProvider', () => {
         fixtures.rubyFileToQuickFix
       );
       const editor = await helper.openFile(filePath);
-      vscode.commands.executeCommand('ruby.rubocop', () => {
-        let fileEdits: vscode.TextEdit[];
 
-        const range = new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 0));
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
-        const quickFixes: vscode.CodeAction[] = instance.provideCodeActions(editor.document, range);
-        expect(quickFixes).to.be.instanceOf(Array);
-        expect(quickFixes.length).to.be.equal(4);
+      const diagnostic = new vscode.Diagnostic(
+        new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 0)),
+`Literal \`{
+      car: 3, # some comment
+    boot: 56, bonnet: 10
+}\` used in void context.`,
+        vscode.DiagnosticSeverity.Warning
+      );
+      diagnostic.source = '(warning:Lint/Void)';
+      diagnostics.set(editor.document.uri, [diagnostic]);
 
-        expect(quickFixes[0].title).to.contain('Ignore `Lint/Void` for this line');
-        expect(quickFixes[0].edit).to.be.instanceOf(vscode.WorkspaceEdit);
-        fileEdits = quickFixes[0].edit.get(editor.document.uri);
-        expect(fileEdits.length).to.be.equal(1);
-        expect(fileEdits[0].newText).to.be.equal('{ # rubocop:disable Lint/Void');
-        expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop');
-        expect(quickFixes[0].command.title).to.be.equal('Lint the file with Rubocop');
-        expect(quickFixes[0].command.arguments).to.be.equal(undefined);
+      let fileEdits: vscode.TextEdit[];
+      let range: vscode.Range;
 
-        expect(quickFixes[1].title).to.contain('Disable `Lint/Void` for this file');
-        fileEdits = quickFixes[1].edit.get(editor.document.uri);
-        expect(fileEdits.length).to.be.equal(2);
-        expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Lint/Void');
-        expect(fileEdits[1].newText).to.be.equal('# rubocop:enable Lint/Void');
-        expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
-        expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
-        expect(quickFixes[1].command.arguments).to.be.equal(undefined);
+      range = new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 0));
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      const quickFixes: vscode.CodeAction[] = instance.provideCodeActions(editor.document, range);
 
-        expect(quickFixes[2].title).to.contain('Disable `Lint/Void` for this project');
-        expect(quickFixes[2].edit).to.be.equal(null);
-        expect(quickFixes[2].command.command).to.be.equal('ruby.rubocop.disableCop');
-        expect(quickFixes[2].command.title).to.be.equal('Disable `Lint/Void` in `.rubocop.yml`');
-        expect(quickFixes[2].command.arguments).to.be.equal([vscode.workspace.workspaceFolders[0], 'Lint/Void']);
+      expect(quickFixes).to.be.instanceOf(Array);
+      expect(quickFixes.length).to.be.equal(3);
 
-        expect(quickFixes[3].title).to.contain('Show documentation for `Lint/Void`');
-        expect(quickFixes[3].edit).to.be.equal(null);
-        expect(quickFixes[3].command.command).to.be.equal('vscode.open');
-        expect(quickFixes[3].command.title).to.be.equal('Show documentation for `Lint/Void`');
-        expect(quickFixes[3].command.arguments).to.be.equal(['https://docs.rubocop.org/rubocop/cops_lint.html#lintvoid']);
+      // Ignore for line
+      expect(quickFixes[0].title).to.contain('Ignore `Lint/Void` for this line');
 
-        fs.unlinkSync(filePath);
-      })
+      expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop');
+      expect(quickFixes[0].command.title).to.be.equal('Lint the file with Rubocop');
+      expect(quickFixes[0].command.arguments).to.be.equal(undefined);
+
+      expect(quickFixes[0].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+      fileEdits = quickFixes[0].edit.get(editor.document.uri);
+      expect(fileEdits.length).to.be.equal(1);
+
+      expect(fileEdits[0].newText).to.be.equal('{ # rubocop:disable Lint/Void');
+      range = new vscode.Range(new vscode.Position(5, 0), new vscode.Position(5, 29));
+      expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
+
+      // Disable for file
+      expect(quickFixes[1].title).to.contain('Disable `Lint/Void` for this file');
+
+      expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
+      expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
+      expect(quickFixes[1].command.arguments).to.be.equal(undefined);
+
+      expect(quickFixes[1].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+      fileEdits = quickFixes[1].edit.get(editor.document.uri);
+      expect(fileEdits.length).to.be.equal(2);
+
+      expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Lint/Void\n');
+      range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+      expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
+
+      expect(fileEdits[1].newText).to.be.equal('\n# rubocop:enable Lint/Void\n');
+      range = new vscode.Range(new vscode.Position(10, 0), new vscode.Position(10, 0));
+      expect(JSON.stringify(fileEdits[1].range)).to.be.equal(JSON.stringify(range));
+
+      // Show documentation
+      expect(quickFixes[2].title).to.contain('Show documentation for `Lint/Void`');
+      expect(quickFixes[2].edit).to.be.equal(undefined);
+
+      expect(quickFixes[2].command.command).to.be.equal('vscode.open');
+      expect(quickFixes[2].command.title).to.be.equal('Show documentation for `Lint/Void`');
+      expect(quickFixes[2].command.arguments.length).to.be.equal(1);
+      expect(quickFixes[2].command.arguments[0]).to.be.equal('https://docs.rubocop.org/rubocop/cops_lint.html#lintvoid');
+
+      fs.unlinkSync(filePath);
     });
 
     it('generates quick fixes for code with a correctable diagnostic', async function () {
@@ -102,71 +127,95 @@ describe('RubocopQuickFixProvider', () => {
         fixtures.rubyFileToQuickFix
       );
       const editor = await helper.openFile(filePath);
-      vscode.commands.executeCommand('ruby.rubocop', () => {
-        let fileEdits: vscode.TextEdit[];
 
-        const range = new vscode.Range(new vscode.Position(7, 7), new vscode.Position(7, 8));
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
-        const quickFixes: vscode.CodeAction[] = instance.provideCodeActions(editor.document, range);
-        expect(quickFixes).to.be.instanceOf(Array);
-        expect(quickFixes.length).to.be.equal(7);
+      await helper.sleep(500);
+      const diagnostic = new vscode.Diagnostic(
+        new vscode.Range(new vscode.Position(6, 7), new vscode.Position(6, 12)),
+        'Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.',
+        vscode.DiagnosticSeverity.Warning
+      );
+      diagnostic.source = '[Correctable](convention:Layout/FirstHashElementIndentation)';
+      diagnostics.set(editor.document.uri, [diagnostic]);
 
-        expect(quickFixes[0].title).to.contain('Fix `Layout/FirstHashElementIndentation` in this file');
-        expect(quickFixes[0].edit).to.be.equal(null);
-        expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop.autocorrect');
-        expect(quickFixes[0].command.title).to.be.equal('Fix `Layout/FirstHashElementIndentation` in this file');
-        expect(quickFixes[0].command.arguments).to.be.equal(['-A', '--only', 'Layout/FirstHashElementIndentation']);
+      let fileEdits: vscode.TextEdit[];
+      let range: vscode.Range;
 
-        expect(quickFixes[1].title).to.contain('Ignore `Layout/FirstHashElementIndentation` for this line');
-        expect(quickFixes[1].edit).to.be.instanceOf(vscode.WorkspaceEdit);
-        fileEdits = quickFixes[1].edit.get(editor.document.uri);
-        expect(fileEdits.length).to.be.equal(1);
-        expect(fileEdits[0].newText).to.be.equal('      car: 3, # rubocop:disable Layout/FirstHashElementIndentation');
-        expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
-        expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
-        expect(quickFixes[1].command.arguments).to.be.equal(undefined);
+      range = new vscode.Range(new vscode.Position(6, 7), new vscode.Position(6, 8));
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      const quickFixes: vscode.CodeAction[] = instance.provideCodeActions(editor.document, range);
 
-        expect(quickFixes[2].title).to.contain('Disable `Layout/FirstHashElementIndentation` for this file');
-        fileEdits = quickFixes[2].edit.get(editor.document.uri);
-        expect(fileEdits.length).to.be.equal(2);
-        expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Layout/FirstHashElementIndentation');
-        expect(fileEdits[1].newText).to.be.equal('# rubocop:enable Layout/FirstHashElementIndentation');
-        expect(quickFixes[2].command.command).to.be.equal('ruby.rubocop');
-        expect(quickFixes[2].command.title).to.be.equal('Lint the file with Rubocop');
-        expect(quickFixes[2].command.arguments).to.be.equal(undefined);
+      expect(quickFixes).to.be.instanceOf(Array);
+      expect(quickFixes.length).to.be.equal(6);
 
-        expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
-        expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
-        expect(quickFixes[1].command.arguments).to.be.equal(undefined);
+      // ==== Fix in file ====
+      expect(quickFixes[0].title).to.contain('Fix `Layout/FirstHashElementIndentation` in this file');
+      expect(quickFixes[0].edit).to.be.equal(undefined);
+      expect(quickFixes[0].command.command).to.be.equal('ruby.rubocop.autocorrect');
+      expect(quickFixes[0].command.title).to.be.equal('Fix `Layout/FirstHashElementIndentation` in this file');
+      expect(JSON.stringify(quickFixes[0].command.arguments)).to.be.equal(JSON.stringify(['-A', '--only', 'Layout/FirstHashElementIndentation']));
 
-        expect(quickFixes[3].title).to.contain('Disable `Layout/FirstHashElementIndentation` for this project');
-        expect(quickFixes[3].edit).to.be.equal(null);
-        expect(quickFixes[3].command.command).to.be.equal('ruby.rubocop.disableCop');
-        expect(quickFixes[3].command.title).to.be.equal('Disable `Layout/FirstHashElementIndentation` in `.rubocop.yml`');
-        expect(quickFixes[3].command.arguments).to.be.equal([vscode.workspace.workspaceFolders[0], 'Layout/FirstHashElementIndentation']);
+      // ==== Ignore for line ====
+      expect(quickFixes[1].title).to.contain('Ignore `Layout/FirstHashElementIndentation` for this line');
 
-        expect(quickFixes[4].title).to.contain('Show documentation for `Layout/FirstHashElementIndentation`');
-        expect(quickFixes[4].edit).to.be.equal(null);
-        expect(quickFixes[4].command.command).to.be.equal('vscode.open');
-        expect(quickFixes[4].command.title).to.be.equal('Show documentation for `Layout/FirstHashElementIndentation`');
-        expect(quickFixes[4].command.arguments).to.be.equal(['https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirsthashelementindentation']);
+      expect(quickFixes[1].command.command).to.be.equal('ruby.rubocop');
+      expect(quickFixes[1].command.title).to.be.equal('Lint the file with Rubocop');
+      expect(quickFixes[1].command.arguments).to.be.equal(undefined);
 
-        expect(quickFixes[5].title).to.contain('Force fixing all warnings')
-        expect(quickFixes[5].edit).to.be.equal(null);
-        expect(quickFixes[5].command.command).to.be.equal('ruby.rubocop.autocorrect');
-        expect(quickFixes[5].command.title).to.be.equal('Force fixing all warnings');
-        expect(quickFixes[5].command.arguments).to.be.equal(['-A']);
+      expect(quickFixes[1].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+      fileEdits = quickFixes[1].edit.get(editor.document.uri);
+      expect(fileEdits.length).to.be.equal(1);
 
-        expect(quickFixes[6].title).to.contain('Fix all warnings safely')
-        expect(quickFixes[6].edit).to.be.equal(null);
-        expect(quickFixes[6].command.command).to.be.equal('ruby.rubocop.autocorrect');
-        expect(quickFixes[6].command.title).to.be.equal('Fix all warnings safely');
-        expect(quickFixes[6].command.arguments).to.be.equal(null);
+      expect(fileEdits[0].newText).to.be.equal(' # rubocop:disable Layout/FirstHashElementIndentation');
+      range = new vscode.Range(new vscode.Position(6, 13), new vscode.Position(6, 66));
+      expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
 
-        fs.unlinkSync(filePath);
-      });
+      // ==== Disable for file ====
+      expect(quickFixes[2].title).to.contain('Disable `Layout/FirstHashElementIndentation` for this file');
 
+      expect(quickFixes[2].command.command).to.be.equal('ruby.rubocop');
+      expect(quickFixes[2].command.title).to.be.equal('Lint the file with Rubocop');
+      expect(quickFixes[2].command.arguments).to.be.equal(undefined);
+
+      expect(quickFixes[2].edit).to.be.instanceOf(vscode.WorkspaceEdit);
+      fileEdits = quickFixes[2].edit.get(editor.document.uri);
+      expect(fileEdits.length).to.be.equal(2);
+
+      expect(fileEdits[0].newText).to.be.equal('# rubocop:disable Layout/FirstHashElementIndentation\n');
+      range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+      expect(JSON.stringify(fileEdits[0].range)).to.be.equal(JSON.stringify(range));
+
+      expect(fileEdits[1].newText).to.be.equal('\n# rubocop:enable Layout/FirstHashElementIndentation\n');
+      range = new vscode.Range(new vscode.Position(10, 0), new vscode.Position(10, 0));
+      expect(JSON.stringify(fileEdits[1].range)).to.be.equal(JSON.stringify(range));
+
+      // ==== Show documentation ====
+      expect(quickFixes[3].title).to.contain('Show documentation for `Layout/FirstHashElementIndentation`');
+      expect(quickFixes[3].edit).to.be.equal(undefined);
+
+      expect(quickFixes[3].command.command).to.be.equal('vscode.open');
+      expect(quickFixes[3].command.title).to.be.equal('Show documentation for `Layout/FirstHashElementIndentation`');
+      expect(quickFixes[3].command.arguments.length).to.be.equal(1);
+      expect(quickFixes[3].command.arguments[0]).to.be.equal('https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirsthashelementindentation');
+
+      // ==== Force fixing ====
+      expect(quickFixes[4].title).to.contain('Force fixing all warnings')
+      expect(quickFixes[4].edit).to.be.equal(undefined);
+
+      expect(quickFixes[4].command.command).to.be.equal('ruby.rubocop.autocorrect');
+      expect(quickFixes[4].command.title).to.be.equal('Force fixing all warnings');
+      expect(quickFixes[4].command.arguments.length).to.be.equal(1);
+      expect(quickFixes[4].command.arguments[0]).to.be.equal('-A');
+
+      // ==== Fix all safely ====
+      expect(quickFixes[5].title).to.contain('Fix all warnings safely')
+      expect(quickFixes[5].edit).to.be.equal(undefined);
+
+      expect(quickFixes[5].command.command).to.be.equal('ruby.rubocop.autocorrect');
+      expect(quickFixes[5].command.title).to.be.equal('Fix all warnings safely');
+      expect(quickFixes[5].command.arguments).to.be.equal(undefined);
+
+      fs.unlinkSync(filePath);
     });
   });
 });


### PR DESCRIPTION
Hi, I implemented quick fixes for Rubocop warnings.

My team has been longing for a feature like this for quite some time.
So I'd decided to try and implement it myself.

And if I may say so myself, it came together pretty nicely.

Auto-correctable cop:

<img width="604" alt="Rubocop Quick Fix Tooltip - Correctable" src="https://user-images.githubusercontent.com/31414818/185810703-1edfe010-cd85-4a07-a5ee-a982d6eec214.png">

<img width="284" alt="Rubocop Quick Fix List - Correctable" src="https://user-images.githubusercontent.com/31414818/185810725-6919d0be-0859-4a1d-b708-930e48aa0fda.png">

Uncorrectable cop:

<img width="647" alt="Rubocop Quick Fix Tooltip - Uncorrectable" src="https://user-images.githubusercontent.com/31414818/185810905-f6870228-ac9c-401a-9df0-76910a30981f.png">

<img width="346" alt="Rubocop Quick Fix List - Uncorrectable" src="https://user-images.githubusercontent.com/31414818/185810938-9674ae32-dfed-4337-84b9-4a4840a38e51.png">


Here's a demo:

![Rubocop Quick Fixes Demo](https://user-images.githubusercontent.com/31414818/185810560-bbc8363e-253e-4b84-9b5f-545949eb8712.gif)
