### PR TITLE
[Fix #8] honor useServer when linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.4
+- Use the Rubocop server when linting if useServer configuration option is set to true (thanks [@gurgeous](https://github.com/gurgeous))
+- Strip 'RuboCop server starting on' from Rubocop output (thanks [@gurgeous](https://github.com/gurgeous))
+
 # 0.9.3
 
 - Introduce quick fix functionality that gives you the possibility to fix or ignore one or more errors (thanks [@Verseth](https://github.com/Verseth)) 

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -132,6 +132,9 @@ ${copName}:
     const args = getCommandArguments(fileName)
       .concat(this.additionalArguments)
       .concat(jsonOutputFormat);
+    if (this.config.useServer) {
+      args.push('--server');
+    }
 
     const task = new Task(uri, (token) => {
       const process = this.executeRubocop(
@@ -199,11 +202,11 @@ ${copName}:
     }
 
     try {
-      rubocop = JSON.parse(output);
+      const json = output.replace(/^RuboCop server starting on.*?\n/, '');
+      rubocop = JSON.parse(json);
     } catch (e) {
       if (e instanceof SyntaxError) {
-        const regex = /[\r\n \t]/g;
-        const message = output.replace(regex, ' ');
+        const message = output.replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
         const errorMessage = `Error on parsing output (It might non-JSON output) : "${message}"`;
         vscode.window.showWarningMessage(errorMessage);
 


### PR DESCRIPTION
Honor the useServer setting when linting, and strip out the "RuboCop server starting" output. I also filed an issue with rubocop to remove that message when running with `--format json` (see https://github.com/rubocop/rubocop/issues/11164).