### PR TITLE
[Fixes #12] - Adds an output channel to the extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
         "command": "ruby.rubocop.autocorrect",
         "when": "editorLangId == 'ruby' || editorLangId == 'gemfile'",
         "title": "Ruby: Autocorrect by Rubocop"
+      },
+      {
+        "command": "ruby.rubocop.showOutputChannel",
+        "when": "editorLangId == 'ruby' || editorLangId == 'gemfile'",
+        "title": "Ruby: Show Rubocop Output Channel"
       }
     ],
     "keybindings": [

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+
+// output channel (lazy)
+export let channel: vscode.OutputChannel | undefined;
+
+// log to our output channel
+export function log(message: string) {
+  if (!channel) {
+    channel = vscode.window.createOutputChannel('Rubocop');
+  }
+
+  // log to channel with timestamp
+  const now = new Date().toISOString()
+  channel.appendLine(`[${now}] ${message}`);
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as cp from 'child_process';
 import * as path from 'path';
 import { Rubocop } from './rubocop';
+import { log } from './channel';
 
 export interface RubocopConfig {
   command: string;
@@ -15,12 +16,17 @@ export interface RubocopConfig {
 }
 
 const detectBundledRubocop: () => boolean = () => {
+  let found: boolean;
   try {
+    log("detectBundledRubocop: bundle show rubocop");
     cp.execSync('bundle show rubocop', { cwd: vs.workspace.rootPath });
-    return true;
+    found = true;
   } catch (e) {
-    return false;
+    found = false;
   }
+
+  log(`detectBundledRubocop: ${found}`);
+  return found;
 };
 
 const autodetectExecutePath: (cmd: string) => string = (cmd) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,13 @@
 import * as vscode from 'vscode';
 import { Rubocop } from './rubocop';
 import { onDidChangeConfiguration } from './configuration';
+import { channel, log } from './channel';
 
 // entry point of extension
 export function activate(context: vscode.ExtensionContext): void {
   'use strict';
+
+  log("activate");
 
   const diag = vscode.languages.createDiagnosticCollection('ruby');
   context.subscriptions.push(diag);
@@ -76,7 +79,7 @@ export function activate(context: vscode.ExtensionContext): void {
   const disableCopDisposable = vscode.commands.registerCommand(
     'ruby.rubocop.disableCop',
     (workspaceFolder?: vscode.WorkspaceFolder, copName?: string) => {
-      if(workspaceFolder === null || copName === null) return;
+      if (workspaceFolder === null || copName === null) return;
 
       rubocop.disableCop(
         workspaceFolder,
@@ -87,4 +90,16 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   context.subscriptions.push(disableCopDisposable);
+
+  //
+  // command for showing our output channel
+  //
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'ruby.rubocop.showOutputChannel',
+      () => channel?.show()
+    ));
+
+  log("activated");
 }

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -10,6 +10,7 @@ import { getConfig, RubocopConfig } from './configuration';
 import RubocopAutocorrectProvider from './rubocopAutocorrectProvider';
 import { getCommandArguments, isFileUri, getCurrentPath } from './helper';
 import RubocopQuickFixProvider from './rubocopQuickFixProvider';
+import { log } from './channel';
 
 export class Rubocop {
   public config: RubocopConfig;
@@ -38,7 +39,7 @@ ${copName}:
 
     const rubocopYamlPath = path.join(workspaceFolder.uri.fsPath, '.rubocop.yml')
     fs.appendFile(rubocopYamlPath, disableCopContent, () => {
-      if(onComplete) onComplete();
+      if (onComplete) onComplete();
     });
   }
 
@@ -68,7 +69,7 @@ ${copName}:
       }
     });
 
-    if(onComplete) promise.then(() => onComplete());
+    if (onComplete) promise.then(() => onComplete());
 
     return true;
   }
@@ -177,12 +178,17 @@ ${copName}:
     options: cp.ExecOptions,
     cb: (err: Error, stdout: string, stderr: string) => void
   ): cp.ChildProcess {
+    const cmd = `${this.config.command} ${args.join(' ')}`;
+    log(`executeRubocop: ${cmd}`);
+
     let child;
     if (this.config.useBundler) {
-      child = cp.exec(`${this.config.command} ${args.join(' ')}`, options, cb);
+      child = cp.exec(cmd, options, cb);
     } else {
       child = cp.execFile(this.config.command, args, options, cb);
     }
+    log("executeRubocop: done");
+
     child.stdin.write(fileContents);
     child.stdin.end();
     return child;
@@ -201,6 +207,8 @@ ${copName}:
     try {
       rubocop = JSON.parse(output);
     } catch (e) {
+      log("JSON.parse failed");
+
       if (e instanceof SyntaxError) {
         const regex = /[\r\n \t]/g;
         const message = output.replace(regex, ' ');

--- a/src/taskQueue.ts
+++ b/src/taskQueue.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { log } from './channel';
 
 export interface TaskToken {
   readonly isCanceled: boolean;
@@ -116,6 +117,7 @@ export class TaskQueue {
       try {
         await task.run();
       } catch (e) {
+        log(`error: ${e.message}`);
         console.error('Error while running rubocop: ', e.message, e.stack);
       }
       this.tasks.shift();


### PR DESCRIPTION
Adds an output channel to the extension. Also a command for showing the channel. I added output to show what the extension is up to, including some benchmarking. Sample output:

```
[2022-11-10T19:57:14.754Z] activate
[2022-11-10T19:57:14.754Z] detectBundledRubocop: bundle show rubocop
[2022-11-10T19:57:15.145Z] detectBundledRubocop: false
[2022-11-10T19:57:15.145Z] detectBundledRubocop: bundle show rubocop
[2022-11-10T19:57:15.403Z] detectBundledRubocop: false
[2022-11-10T19:57:15.406Z] executeRubocop: /Users/xxx/.asdf/shims/rubocop --stdin /Users/xxx/test.rb --force-exclusion --format json
[2022-11-10T19:57:15.407Z] executeRubocop: done
[2022-11-10T19:57:15.407Z] activated
[2022-11-10T19:57:24.148Z] detectBundledRubocop: bundle show rubocop
[2022-11-10T19:57:24.405Z] detectBundledRubocop: false
[2022-11-10T19:57:24.405Z] detectBundledRubocop: bundle show rubocop
[2022-11-10T19:57:24.667Z] detectBundledRubocop: false
[2022-11-10T19:57:24.667Z] autocorrect: /Users/xxx/.asdf/shims/rubocop --stdin /Users/xxx/test.rb --force-exclusion --autocorrect
[2022-11-10T19:57:25.880Z] autocorrect: done
[2022-11-10T19:57:25.924Z] detectBundledRubocop: bundle show rubocop
[2022-11-10T19:57:26.168Z] detectBundledRubocop: false
[2022-11-10T19:57:26.168Z] executeRubocop: /Users/xxx/.asdf/shims/rubocop --stdin /Users/xxx/test.rb --force-exclusion --format json
[2022-11-10T19:57:26.169Z] executeRubocop: done
```