### PR TITLE
Fix autocorrection command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Specify configuration (via navigating to `File > Preferences > Workspace Setting
 You can change the keybinding (via editing `keybindings.json`)
 
 ```javascript
-{ "key": "ctrl+alt+l",          "command": "ruby.rubocopAutocorrect",
+{ "key": "ctrl+alt+l",          "command": "ruby.rubocop.autocorrect",
                                 "when": "editorLangId == 'ruby'" }
 ```
 


### PR DESCRIPTION
Thank you *very much* for this extension. 

The provided keybinding command in the README resulted in an error. This proposed command works on my machine. :-)