### PR TITLE
✨ Add setting to hide Disable/Ignore suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Specify configuration (via navigating to `File > Preferences > Workspace Setting
   
   // use the --server option when running Rubocop - default false
   "ruby.rubocop.useServer": true
+
+  // If "true", it hides all the Disable/Ignore options, nudging to prefer fixing violations
+  "ruby.rubocop.hideDisableSuggestions": false
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
           "type": "boolean",
           "default": false,
           "description": "Suppress warnings from rubocop and attempt to run regardless. (Useful if you share a rubocop.yml file and run into unrecognized cop errors you know are okay.)"
+        },
+        "ruby.rubocop.hideDisableSuggestions": {
+          "type": "boolean",
+          "default": false,
+          "description": "Hide the 'Disable' suggestions, nudging to prefer fixing violations."
         }
       }
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -12,6 +12,7 @@ export interface RubocopConfig {
   useBundler: boolean;
   useServer: boolean;
   suppressRubocopWarnings: boolean;
+  hideDisableSuggestions: boolean;
 }
 
 const detectBundledRubocop: () => boolean = () => {
@@ -53,6 +54,7 @@ export const getConfig: () => RubocopConfig = () => {
   const useServer = conf.get('useServer', false);
   const configPath = conf.get('executePath', '');
   const suppressRubocopWarnings = conf.get('suppressRubocopWarnings', false);
+  const hideDisableSuggestions = conf.get('hideDisableSuggestions', false);
   let command: string;
 
   // if executePath is present in workspace config, use it.
@@ -79,6 +81,7 @@ export const getConfig: () => RubocopConfig = () => {
     useBundler,
     useServer,
     suppressRubocopWarnings,
+    hideDisableSuggestions,
   };
 };
 

--- a/src/rubocopQuickFixProvider.ts
+++ b/src/rubocopQuickFixProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { getConfig } from './configuration';
 
 const initialWhitespaceRegexp = /^\s+/
 const correctableDiagnosticRegexp = /^\[Correctable\]/;
@@ -57,14 +58,16 @@ export default class RubocopQuickFixProvider
     const autocorrectQuickFix = this.autocorrectCopInFile(copName, diagnostic);
     if(autocorrectQuickFix !== null) quickFixes.push(autocorrectQuickFix);
 
-    const ignoreCopForLineQuickFix = this.ignoreCopForLineQuickFix(document, copName, diagnostic);
-    if(ignoreCopForLineQuickFix !== null) quickFixes.push(ignoreCopForLineQuickFix);
+    const config = getConfig();
+    if (!config.hideDisableSuggestions) {
+      const ignoreCopForLineQuickFix = this.ignoreCopForLineQuickFix(document, copName, diagnostic);
+      if(ignoreCopForLineQuickFix !== null) quickFixes.push(ignoreCopForLineQuickFix);
 
-    quickFixes.push(this.disableCopForFileQuickFix(document, copName, diagnostic));
+      quickFixes.push(this.disableCopForFileQuickFix(document, copName, diagnostic));
 
-    const disableCopInRubocopYaml = this.disableCopInRubocopYaml(document, copName, diagnostic);
-    if(disableCopInRubocopYaml !== null) quickFixes.push(disableCopInRubocopYaml);
-
+      const disableCopInRubocopYaml = this.disableCopInRubocopYaml(document, copName, diagnostic);
+      if(disableCopInRubocopYaml !== null) quickFixes.push(disableCopInRubocopYaml);
+    }
     quickFixes.push(this.showCopDocumentation(copName, diagnostic));
 
     return quickFixes;

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -22,6 +22,7 @@ vsStub.workspace.getConfiguration = (
     autocorrectOnSave: false,
     useBundler: false,
     suppressRubocopWarnings: false,
+    hideDisableSuggestions: false,
   };
 
   return {
@@ -73,6 +74,16 @@ describe('RubocopConfig', () => {
     describe('.suppressRubocopWarnings', () => {
       it('is set to false', () => {
         expect(getConfig()).to.have.property('suppressRubocopWarnings', false);
+      });
+    });
+
+    describe('.hideDisableSuggestions', () => {
+      it('is set', () => {
+        expect(getConfig()).to.have.property('hideDisableSuggestions');
+      });
+
+      it('is set to false by default', () => {
+        expect(getConfig()).to.have.property('hideDisableSuggestions', false);
       });
     });
 

--- a/test/rubocopQuickFixProvider.test.ts
+++ b/test/rubocopQuickFixProvider.test.ts
@@ -338,5 +338,71 @@ describe('RubocopQuickFixProvider', () => {
 
       fs.unlinkSync(filePath);
     });
+
+    describe('when hideDisableSuggestions is enabled', () => {
+      let quickFixes: vscode.CodeAction[];
+
+      beforeEach(async function() {
+        this.timeout(5000);
+        await helper.closeAllEditors();
+        
+        // override vs.workspace.getConfiguration to return default values for each of the extension's
+        // defined configuration options, and not depend on what is configured by the user
+        const { getConfiguration: _getConfiguration } = vscode.workspace;
+
+        vscode.workspace.getConfiguration = (
+          section?: string,
+          resource?: vscode.Uri | null
+        ): any => {
+          // FIXME: we should replace only get
+          if (section !== 'ruby.rubocop') {
+            return _getConfiguration(section, resource);
+          }
+
+          const defaultConfig = {
+            configfilePath: '',
+            executePath: '',
+            onSave: true,
+            autocorrectOnSave: false,
+            useBundler: false,
+            suppressRubocopWarnings: false,
+            hideDisableSuggestions: true,
+          };
+
+          return {
+            get: <T>(section: string, defaultValue?: T): T | undefined =>
+              defaultConfig[section] || defaultValue,
+          };
+        };
+      });
+
+      it('hides the Disable suggestions', async function() {
+        const filePath = helper.createTempFile(
+          'file_to_quick_fix.rb',
+          fixtures.rubyFileToQuickFix
+        );
+        const editor = await helper.openFile(filePath);
+
+        await helper.sleep(500);
+        const diagnostic = new vscode.Diagnostic(
+          new vscode.Range(new vscode.Position(6, 7), new vscode.Position(6, 12)),
+          'Use 2 spaces for indentation in a hash, relative to the start of the line where the left curly brace is.',
+          vscode.DiagnosticSeverity.Warning
+        );
+        diagnostic.source = '[Correctable](convention:Layout/FirstHashElementIndentation)';
+        diagnostics.set(editor.document.uri, [diagnostic]);
+
+        const range = new vscode.Range(new vscode.Position(6, 7), new vscode.Position(6, 8));
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        quickFixes = instance.provideCodeActions(editor.document, range);
+
+        expect(quickFixes).to.be.instanceOf(Array);
+        expect(quickFixes.length).to.be.equal(4);
+        expect(quickFixes.filter((quickFix) => quickFix.title.includes('Disable') || quickFix.title.includes('Ignore'))).to.be.empty;
+
+        fs.unlinkSync(filePath);
+      });
+    });
   });
 });


### PR DESCRIPTION
This allows to hide the "Disable/Ignore" suggestions, in order to nudge the user to fix the violation, instead of ignoring it.

This is what it looks like:

<img width="436" alt="image" src="https://user-images.githubusercontent.com/104916/227649228-c80914e7-1b83-46e8-b466-0e75946213c3.png">

Closes #18 