### PR TITLE
Added autocorrectArg config option so that users can run RuboCop with --autocorrect-all (-A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Specify configuration (via navigating to `File > Preferences > Workspace Setting
   // "ruby.rubocop.executePath": "/Users/you/.rvm/gems/ruby-2.3.2/bin/"
   // "ruby.rubocop.executePath": "D:/bin/Ruby22-x64/bin/"
 
+  // Set to "--autocorrect-all" to enable "unsafe" auto-corrections
+  "ruby.rubocop.autocorrectArg": "--autocorrect",
+
   // If not specified, it assumes a null value by default.
   "ruby.rubocop.configFilePath": "/path/to/config/.rubocop.yml",
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
           "default": "",
           "description": "execution path of rubocop."
         },
+        "ruby.rubocop.autocorrectArg": {
+          "type": "string",
+          "default": "--autocorrect",
+          "description": "RuboCop argument for autocorrect. Use --autocorrect-all to include unsafe autocorrections."
+        },
         "ruby.rubocop.configFilePath": {
           "type": "string",
           "default": "",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -7,6 +7,7 @@ import { log } from './channel';
 
 export interface RubocopConfig {
   command: string;
+  autocorrectArg: string;
   onSave: boolean;
   autocorrectOnSave: boolean;
   configFilePath: string;
@@ -81,6 +82,7 @@ export const getConfig: () => RubocopConfig = () => {
 
   return {
     command,
+    autocorrectArg: conf.get('autocorrectArg', '--autocorrect'),
     configFilePath: conf.get('configFilePath', ''),
     onSave: conf.get('onSave', true),
     autocorrectOnSave: conf.get('autocorrectOnSave', false),

--- a/src/rubocopAutocorrectProvider.ts
+++ b/src/rubocopAutocorrectProvider.ts
@@ -15,8 +15,7 @@ export default class RubocopAutocorrectProvider
     const config = getConfig();
     try {
       const args = [...getCommandArguments(document.fileName), ...additionalArguments];
-      if (additionalArguments.length === 0) args.push('--autocorrect');
-
+      if (additionalArguments.length === 0) args.push(config.autocorrectArg);
       if (config.useServer) {
         args.push('--server');
       }

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -18,6 +18,7 @@ vsStub.workspace.getConfiguration = (
   const defaultConfig = {
     configfilePath: '',
     executePath: '',
+    autocorrectArg: '--autocorrect',
     onSave: true,
     autocorrectOnSave: false,
     useBundler: false,
@@ -155,6 +156,12 @@ describe('RubocopConfig', () => {
       describe('.onSave', () => {
         it('is set', () => {
           expect(getConfig()).to.have.property('onSave');
+        });
+      });
+
+      describe('.autocorrectArg', () => {
+        it('is set', () => {
+          expect(getConfig().autocorrectArg).to.eq('--autocorrect');
         });
       });
     });


### PR DESCRIPTION
Hi, thanks for maintaining this! I've been using a fork of this extension for a long time, where I made it possible to configure the auto-correct argument. Instead of --auto-correct, I like to run it with --auto-correct-all. My actual setting is:

```
"ruby.rubocop.autocorrectArg": "--except Lint/UnusedMethodArgument,Lint/UnusedBlockArgument --auto-correct-all",
```

So that it doesn't delete unused arguments or prepend an underscore.

Thanks!